### PR TITLE
Rebrand Basic → Free and gate Free plan when >1 topic selected

### DIFF
--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -17,7 +17,7 @@ export async function POST(request: NextRequest) {
   }
 
   const body = await request.json().catch(() => ({}));
-  const plan = body.plan === 'pro' ? 'pro' : 'basic';
+  const plan = body.plan === 'pro' ? 'pro' : 'free';
 
   const rawCity = typeof body.city === 'string' ? body.city.trim() : '';
   const rawLanguage = typeof body.language === 'string' ? body.language.trim() : '';
@@ -48,6 +48,7 @@ export async function POST(request: NextRequest) {
 
   const referralCode = typeof body.referralCode === 'string' ? body.referralCode.trim() : '';
 
+  // Env var intentionally named STRIPE_BASIC_PRICE_ID — UI labels the tier "Free" but the Stripe price config retains the original name to avoid a coordinated secrets rotation.
   const priceId = plan === 'pro'
     ? process.env.STRIPE_PRO_PRICE_ID!
     : process.env.STRIPE_BASIC_PRICE_ID!;
@@ -98,7 +99,7 @@ export async function POST(request: NextRequest) {
         quantity: 1,
       },
     ],
-    ...(plan === 'basic' && { payment_method_collection: 'if_required' as const }),
+    ...(plan === 'free' && { payment_method_collection: 'if_required' as const }),
     success_url: `${origin}/local?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${origin}/local/onboarding?checkout=cancel`,
     metadata,

--- a/components/local/onboarding/onboarding-wizard.tsx
+++ b/components/local/onboarding/onboarding-wizard.tsx
@@ -72,7 +72,7 @@ export function OnboardingWizard() {
   };
 
   const handleCheckout = useCallback(
-    async (plan: "basic" | "pro") => {
+    async (plan: "free" | "pro") => {
       setCheckoutError(null);
 
       if (!user) {

--- a/components/local/onboarding/plan-step.tsx
+++ b/components/local/onboarding/plan-step.tsx
@@ -7,21 +7,20 @@ import { OnboardingState } from "./types";
 interface Props {
   state: OnboardingState;
   isRedirecting: boolean;
-  onCheckout: (plan: "basic" | "pro") => void;
+  onCheckout: (plan: "free" | "pro") => void;
 }
 
 export function PlanStep({ state, isRedirecting, onCheckout }: Props) {
-  const [pending, setPending] = useState<"basic" | "pro" | null>(null);
+  const [pending, setPending] = useState<"free" | "pro" | null>(null);
 
   useEffect(() => {
     if (!isRedirecting) setPending(null);
   }, [isRedirecting]);
 
   const pickedCount = state.topics.length;
-  const firstTopic = state.topics[0];
-  const basicWouldTruncate = pickedCount >= 2;
+  const freeRequiresFewerTopics = pickedCount > 1;
 
-  const handleClick = (plan: "basic" | "pro") => {
+  const handleClick = (plan: "free" | "pro") => {
     setPending(plan);
     onCheckout(plan);
   };
@@ -42,11 +41,10 @@ export function PlanStep({ state, isRedirecting, onCheckout }: Props) {
         <ExternalLink className="w-3.5 h-3.5" />
       </a>
 
-      {basicWouldTruncate && (
+      {freeRequiresFewerTopics && (
         <div className="mb-5 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3">
           <p className="text-[13px] text-gray-600 leading-relaxed">
-            Heads up: Basic includes one topic, so we&rsquo;ll keep{" "}
-            <span className="font-semibold text-gray-900">{firstTopic}</span>. Pro includes all three.
+            Free includes one topic. Deselect extras or pick Pro to unlock all three.
           </p>
         </div>
       )}
@@ -54,11 +52,11 @@ export function PlanStep({ state, isRedirecting, onCheckout }: Props) {
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <button
           type="button"
-          onClick={() => handleClick("basic")}
-          disabled={isRedirecting}
-          className="w-full min-h-[64px] px-6 py-4 text-[15.5px] font-bold text-gray-800 bg-white border-2 border-gray-200 rounded-xl hover:border-gray-400 hover:bg-gray-50 transition-colors disabled:opacity-50"
+          onClick={() => handleClick("free")}
+          disabled={isRedirecting || freeRequiresFewerTopics}
+          className="w-full min-h-[64px] px-6 py-4 text-[15.5px] font-bold text-gray-800 bg-white border-2 border-gray-200 rounded-xl hover:border-gray-400 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
         >
-          {pending === "basic" && isRedirecting ? "Redirecting…" : "Start free"}
+          {pending === "free" && isRedirecting ? "Redirecting…" : "Start free"}
         </button>
 
         <button

--- a/components/local/onboarding/topics-step.tsx
+++ b/components/local/onboarding/topics-step.tsx
@@ -31,7 +31,7 @@ export function TopicsStep({ state, updateState, onContinue }: Props) {
   return (
     <div>
       <p className="text-[15px] text-gray-500 leading-relaxed mb-6">
-        Pick the issues you care about. Basic sends one; Pro sends all three.
+        Pick the issues you care about. Free sends one; Pro sends all three.
       </p>
 
       <label className="block mb-4 text-[11px] font-bold text-gray-400 uppercase tracking-widest">

--- a/components/local/onboarding/use-onboarding-state.ts
+++ b/components/local/onboarding/use-onboarding-state.ts
@@ -11,7 +11,7 @@ import {
 export const ONBOARDING_STORAGE_KEY = "nv_onboarding_v1";
 const TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
-export type PendingPlan = "basic" | "pro" | null;
+export type PendingPlan = "free" | "pro" | null;
 
 export interface StoredOnboardingBlob {
   version: 1;

--- a/components/local/subscription-dashboard.tsx
+++ b/components/local/subscription-dashboard.tsx
@@ -262,7 +262,7 @@ export function SubscriptionDashboard() {
               Cancel your subscription?
             </DialogTitle>
             <DialogDescription className="text-[14px] text-gray-500 mt-1 leading-relaxed">
-              You&apos;ll keep {tier === 'pro' ? 'Pro' : 'Basic'} access until the end of your current billing period. After that, your subscription will be removed.
+              You&apos;ll keep {tier === 'pro' ? 'Pro' : 'Free'} access until the end of your current billing period. After that, your subscription will be removed.
             </DialogDescription>
           </DialogHeader>
           <div className="flex flex-col gap-2.5 mt-4">

--- a/components/local/tier-badge.tsx
+++ b/components/local/tier-badge.tsx
@@ -1,7 +1,7 @@
 import { Badge } from '@/components/ui/badge';
 
 interface TierBadgeProps {
-  tier: 'pro' | 'basic' | 'none';
+  tier: 'pro' | 'free' | 'none';
 }
 
 export function TierBadge({ tier }: TierBadgeProps) {
@@ -17,7 +17,7 @@ export function TierBadge({ tier }: TierBadgeProps) {
 
   return (
     <Badge className="bg-gray-200 text-gray-600 border-transparent text-[11px] font-bold uppercase tracking-wide hover:bg-gray-200">
-      Local Basic
+      Local Free
     </Badge>
   );
 }

--- a/hooks/use-subscription.ts
+++ b/hooks/use-subscription.ts
@@ -8,7 +8,7 @@ interface SubscriptionState {
   isAuthenticated: boolean;
   isLoading: boolean;
   hasSubscription: boolean;
-  tier: 'pro' | 'basic' | 'none';
+  tier: 'pro' | 'free' | 'none';
 }
 
 export function useSubscription(): SubscriptionState & { refetch: () => void } {

--- a/server-actions/fulfill-checkout.ts
+++ b/server-actions/fulfill-checkout.ts
@@ -39,7 +39,7 @@ export async function fulfillCheckout(sessionId: string): Promise<{ success: boo
   }
 
   const metadata = session.metadata ?? {}
-  const plan = metadata.plan === "pro" ? "pro" : "basic"
+  const plan = metadata.plan === "pro" ? "pro" : "free"
   const city = typeof metadata.city === "string" ? metadata.city.trim() : ""
   const language = typeof metadata.language === "string" ? metadata.language.trim() : ""
   const topicsRaw = typeof metadata.topics === "string" ? metadata.topics : ""

--- a/server-actions/get-subscription-status.ts
+++ b/server-actions/get-subscription-status.ts
@@ -7,7 +7,7 @@ export async function getSubscriptionStatus(): Promise<{
   isPro: boolean;
   isAuthenticated: boolean;
   hasSubscription: boolean;
-  tier: 'pro' | 'basic' | 'none';
+  tier: 'pro' | 'free' | 'none';
 }> {
   const supabase = await createSupabaseServerClient()
   const { data: { user } } = await supabase.auth.getUser()
@@ -44,6 +44,6 @@ export async function getSubscriptionStatus(): Promise<{
     isPro,
     isAuthenticated: true,
     hasSubscription: true,
-    tier: isPro ? 'pro' : 'basic',
+    tier: isPro ? 'pro' : 'free',
   }
 }


### PR DESCRIPTION
## Summary
- Disables the **Start free** button on the plan step when the user has picked more than one topic; the existing warning box now reads as a gating explanation pointing them toward Pro.
- Renames the `"basic"` string literal to `"free"` across the internal `"basic" | "pro"` type unions, Stripe-session fallbacks, and subscription-status helpers. User-facing labels (tier badge, topics-step intro, cancel dialog) also flip from "Basic" to "Free".
- `STRIPE_BASIC_PRICE_ID` env var is intentionally kept as-is to avoid a coordinated secrets rotation across local + Vercel. A comment at the lookup site explains why. Old Stripe sessions whose `metadata.plan === "basic"` still fulfill correctly because `fulfill-checkout` and `checkout/route` both use a `=== "pro" ? "pro" : <fallback>` pattern — the fallback just switches from `"basic"` to `"free"`.
- No DB migration needed: the `subscriptions` table has no `tier` column; tier is computed fresh from Stripe price IDs in `get-subscription-status.ts` each request.

## Test plan
- [ ] `/local/onboarding` unauth → pick city + language + **2 topics** → step 4. Free button is visibly disabled and the warning reads "Free includes one topic. Deselect extras or pick Pro to unlock all three." Pro remains clickable.
- [ ] Go back to step 3, deselect to 1 topic → step 4. Free button is enabled, warning box is gone.
- [ ] Pick 3 topics → step 4 → Pro flow works end-to-end.
- [ ] New checkout with Free (1 topic) → `/local` → tier badge reads **Local Free**.
- [ ] Open cancel-subscription dialog on dashboard for a Free user → copy reads "You'll keep Free access until…".
- [ ] `useSubscription()` return value → `tier` is `'free'` (not `'basic'`).
- [ ] `pnpm build` clean compile ✅ (already verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)