### PR TITLE
Add city autocomplete with supported-first suggestions

### DIFF
--- a/app/api/cities/search/route.ts
+++ b/app/api/cities/search/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const runtime = 'edge';
+
+interface PhotonFeature {
+  properties?: {
+    name?: string;
+    city?: string;
+    country?: string;
+    state?: string;
+    osm_value?: string;
+  };
+}
+
+interface PhotonResponse {
+  features?: PhotonFeature[];
+}
+
+export async function GET(request: NextRequest) {
+  const q = request.nextUrl.searchParams.get('q')?.trim() ?? '';
+  if (q.length < 2) {
+    return NextResponse.json({ cities: [] });
+  }
+
+  const url = new URL('https://photon.komoot.io/api/');
+  url.searchParams.set('q', q);
+  url.searchParams.set('limit', '8');
+  url.searchParams.set('osm_tag', 'place:city');
+  url.searchParams.append('osm_tag', 'place:town');
+
+  try {
+    const res = await fetch(url.toString(), {
+      headers: { 'User-Agent': 'NextVoters/1.0 (hello@nextvoters.com)' },
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) {
+      return NextResponse.json({ cities: [] });
+    }
+    const data = (await res.json()) as PhotonResponse;
+
+    const seen = new Set<string>();
+    const cities: Array<{ label: string; name: string; country: string | null }> = [];
+    for (const feat of data.features ?? []) {
+      const name = feat.properties?.name?.trim();
+      if (!name) continue;
+      const country = feat.properties?.country?.trim() || null;
+      const state = feat.properties?.state?.trim();
+      const key = `${name.toLowerCase()}|${country?.toLowerCase() ?? ''}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const label = [name, state, country].filter(Boolean).join(', ');
+      cities.push({ label, name, country });
+    }
+
+    return NextResponse.json({ cities });
+  } catch {
+    return NextResponse.json({ cities: [] });
+  }
+}

--- a/components/local/onboarding/city-step.tsx
+++ b/components/local/onboarding/city-step.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { MapPin } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { Check, MapPin, Search } from "lucide-react";
 import { OnboardingState } from "./types";
 
 interface Props {
@@ -10,6 +10,12 @@ interface Props {
   citiesLoading: boolean;
   updateState: (patch: Partial<OnboardingState>) => void;
   onContinue: (cityWasSupported: boolean) => void;
+}
+
+interface PhotonSuggestion {
+  label: string;
+  name: string;
+  country: string | null;
 }
 
 export function CityStep({
@@ -23,6 +29,82 @@ export function CityStep({
     state.city || state.cityRequest?.city || "",
   );
   const [error, setError] = useState<string | null>(null);
+  const [apiSuggestions, setApiSuggestions] = useState<PhotonSuggestion[]>([]);
+  const [suggestionsLoading, setSuggestionsLoading] = useState(false);
+  const [suggestionsOpen, setSuggestionsOpen] = useState(false);
+  const [pickedCity, setPickedCity] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const trimmed = input.trim();
+    if (trimmed.length < 2 || trimmed === pickedCity) {
+      setApiSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      setSuggestionsLoading(true);
+      try {
+        const res = await fetch(
+          `/api/cities/search?q=${encodeURIComponent(trimmed)}`,
+          { signal: controller.signal },
+        );
+        if (!res.ok) {
+          setApiSuggestions([]);
+          return;
+        }
+        const data = (await res.json()) as { cities?: PhotonSuggestion[] };
+        setApiSuggestions(data.cities ?? []);
+      } catch (err) {
+        if ((err as Error).name !== "AbortError") setApiSuggestions([]);
+      } finally {
+        setSuggestionsLoading(false);
+      }
+    }, 250);
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [input, pickedCity]);
+
+  const { supportedMatches, otherSuggestions } = useMemo(() => {
+    const trimmed = input.trim().toLowerCase();
+    if (trimmed.length < 1) {
+      return { supportedMatches: [], otherSuggestions: apiSuggestions };
+    }
+    const supportedMatches = supportedCities.filter((c) =>
+      c.toLowerCase().includes(trimmed),
+    );
+    const supportedSet = new Set(supportedMatches.map((c) => c.toLowerCase()));
+    const otherSuggestions = apiSuggestions.filter(
+      (s) => !supportedSet.has(s.name.toLowerCase()),
+    );
+    return { supportedMatches, otherSuggestions };
+  }, [input, supportedCities, apiSuggestions]);
+
+  const hasDropdown =
+    suggestionsOpen &&
+    (supportedMatches.length > 0 ||
+      otherSuggestions.length > 0 ||
+      suggestionsLoading);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setSuggestionsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handlePick = (name: string) => {
+    setInput(name);
+    setPickedCity(name);
+    setApiSuggestions([]);
+    setSuggestionsOpen(false);
+    setError(null);
+  };
 
   const handleContinue = () => {
     setError(null);
@@ -46,7 +128,9 @@ export function CityStep({
   return (
     <div>
       <p className="text-[15px] text-gray-500 leading-relaxed mb-6">
-        Where do you want civic updates for? Type any city — if we don&rsquo;t cover it yet, we&rsquo;ll add you to the waitlist.
+        Where do you want civic updates for? Pick a city from the list or type
+        any city — if we don&rsquo;t cover it yet, we&rsquo;ll add you to the
+        waitlist.
       </p>
 
       <label
@@ -56,29 +140,107 @@ export function CityStep({
         City
       </label>
 
-      <div className="flex items-stretch border border-gray-200 rounded-xl overflow-hidden bg-white focus-within:border-brand focus-within:ring-2 focus-within:ring-brand/20">
-        <div className="flex items-center justify-center px-3 border-r border-gray-200 bg-gray-50">
-          <MapPin className="h-4 w-4 text-gray-400" aria-hidden="true" />
+      <div ref={containerRef} className="relative">
+        <div className="flex items-stretch border border-gray-200 rounded-xl overflow-hidden bg-white focus-within:border-brand focus-within:ring-2 focus-within:ring-brand/20">
+          <div className="flex items-center justify-center px-3 border-r border-gray-200 bg-gray-50">
+            <Search className="h-4 w-4 text-gray-400" aria-hidden="true" />
+          </div>
+          <input
+            id="onb-city"
+            type="text"
+            autoComplete="off"
+            placeholder="Start typing a city name…"
+            value={input}
+            onChange={(e) => {
+              setInput(e.target.value);
+              setPickedCity("");
+              setError(null);
+              setSuggestionsOpen(true);
+            }}
+            onFocus={() => setSuggestionsOpen(true)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleContinue();
+              }
+              if (e.key === "Escape") {
+                setSuggestionsOpen(false);
+              }
+            }}
+            className="flex-1 min-w-0 px-3 py-3 text-[14.5px] text-gray-950 placeholder:text-gray-400 focus:outline-none"
+            disabled={citiesLoading}
+          />
         </div>
-        <input
-          id="onb-city"
-          type="text"
-          autoComplete="off"
-          placeholder="E.g. Vancouver"
-          value={input}
-          onChange={(e) => {
-            setInput(e.target.value);
-            setError(null);
-          }}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              handleContinue();
-            }
-          }}
-          className="flex-1 min-w-0 px-3 py-3 text-[14.5px] text-gray-950 placeholder:text-gray-400 focus:outline-none"
-          disabled={citiesLoading}
-        />
+
+        {hasDropdown && (
+          <div
+            className="absolute left-0 right-0 z-[60] mt-1 max-h-[320px] overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg"
+            role="listbox"
+          >
+            {supportedMatches.length > 0 && (
+              <div>
+                <p className="px-3 pt-2.5 pb-1 text-[11px] font-bold text-brand uppercase tracking-widest">
+                  Available now
+                </p>
+                <ul>
+                  {supportedMatches.map((city) => (
+                    <li key={`sup-${city}`} role="option" aria-selected={input === city}>
+                      <button
+                        type="button"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={() => handlePick(city)}
+                        className="w-full flex items-center gap-2 text-left px-3 py-2.5 text-[14px] text-gray-900 hover:bg-brand/5"
+                      >
+                        <Check className="w-4 h-4 text-brand shrink-0" aria-hidden="true" />
+                        <span className="font-semibold">{city}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {otherSuggestions.length > 0 && (
+              <div>
+                {supportedMatches.length > 0 && (
+                  <div className="border-t border-gray-100" />
+                )}
+                <p className="px-3 pt-2.5 pb-1 text-[11px] font-bold text-gray-400 uppercase tracking-widest">
+                  Request a city
+                </p>
+                <ul>
+                  {otherSuggestions.map((s) => (
+                    <li key={s.label} role="option" aria-selected={pickedCity === s.name}>
+                      <button
+                        type="button"
+                        onMouseDown={(e) => e.preventDefault()}
+                        onClick={() => handlePick(s.name)}
+                        className="w-full flex items-start gap-2 text-left px-3 py-2.5 text-[13.5px] hover:bg-gray-50"
+                      >
+                        <MapPin className="w-4 h-4 text-gray-400 shrink-0 mt-0.5" aria-hidden="true" />
+                        <span>
+                          <span className="font-semibold text-gray-900">{s.name}</span>
+                          {s.label !== s.name && (
+                            <span className="text-gray-500">
+                              {" — "}
+                              {s.label.replace(`${s.name}, `, "")}
+                            </span>
+                          )}
+                        </span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {supportedMatches.length === 0 &&
+              otherSuggestions.length === 0 &&
+              suggestionsLoading && (
+                <p className="px-3 py-3 text-[13px] text-gray-400">Searching…</p>
+              )}
+          </div>
+        )}
       </div>
 
       {error && (


### PR DESCRIPTION
## Summary
Restores the `/api/cities/search` edge route (Photon, OSM-based, no key) and wires the onboarding `CityStep` to a debounced autocomplete dropdown.

**Dropdown layout when user types 2+ chars:**
- **Available now** — supported cities matching the input (checkmark icon, brand color). Picking one pre-selects the subscribe path.
- **Request a city** — Photon global matches (excluding duplicates of the supported set). Picking one pre-selects the request path.
- Users can still type freely and hit Continue; the case-insensitive cross-reference at commit time is unchanged — whatever's typed is either matched against `supported_cities` (subscribe) or sent to the request flow.

## Files
- `app/api/cities/search/route.ts` (new) — edge runtime, proxies `photon.komoot.io`, filters to `place:city|town`, revalidates hourly, dedupes by `name|country`.
- `components/local/onboarding/city-step.tsx` — debounced fetch (250ms), two-section dropdown, click-outside to dismiss, `Escape` to close, `Enter` to continue.

## Test plan
- [ ] `/local/onboarding` → type "van" → "Vancouver" appears under **Available now** with a checkmark. Other cities show under **Request a city**.
- [ ] Click "Vancouver" → input populates, dropdown closes → Continue → subscribe flow.
- [ ] Type "portland" → no supported matches, Photon suggestions appear → click "Portland" → request flow.
- [ ] Type a city not in the suggestions list (e.g., "Atlantis") → Continue → request flow with literal input.
- [ ] `Escape` closes the dropdown. Click outside the input area closes it too.
- [ ] `pnpm build` clean ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)