### PR TITLE
Finish subscribe checkout at /local instead of onboarding

### DIFF
--- a/app/local/page.tsx
+++ b/app/local/page.tsx
@@ -1,12 +1,34 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
 import { useSubscription } from '@/hooks/use-subscription';
 import { SubscriptionDashboard } from '@/components/local/subscription-dashboard';
 import { fulfillCheckout } from '@/server-actions/fulfill-checkout';
-import { clearOnboardingBlob } from '@/components/local/onboarding/use-onboarding-state';
+import {
+  ONBOARDING_STORAGE_KEY,
+  clearOnboardingBlob,
+  readOnboardingBlob,
+  type StoredOnboardingBlob,
+} from '@/components/local/onboarding/use-onboarding-state';
+
+// Synchronously clear pendingPlan from the stored blob before navigating to
+// Stripe, so a back-button bounce doesn't re-fire the kickoff.
+function clearPendingPlanInStorage() {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = window.localStorage.getItem(ONBOARDING_STORAGE_KEY);
+    if (!raw) return;
+    const blob = JSON.parse(raw) as StoredOnboardingBlob;
+    blob.pendingPlan = null;
+    blob.updatedAt = Date.now();
+    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(blob));
+  } catch {
+    /* ignore */
+  }
+}
 
 function NVLocalInner() {
   const router = useRouter();
@@ -14,10 +36,14 @@ function NVLocalInner() {
   const { user, isLoading: authLoading } = useAuth();
   const { hasSubscription, isLoading: subLoading, refetch } = useSubscription();
   const [fulfilling, setFulfilling] = useState(false);
+  const [kickoffState, setKickoffState] = useState<'idle' | 'running' | 'error'>('idle');
+  const [kickoffError, setKickoffError] = useState<string | null>(null);
+  const kickoffFiredRef = useRef(false);
 
   const isPostCheckout = searchParams.get('checkout') === 'success';
   const sessionId = searchParams.get('session_id');
 
+  // Post-Stripe fulfillment.
   useEffect(() => {
     if (!isPostCheckout || !sessionId || !user) return;
     setFulfilling(true);
@@ -29,24 +55,115 @@ function NVLocalInner() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isPostCheckout, sessionId, user]);
 
-  // Unauth and authed-without-subscription users both funnel through onboarding.
-  // Onboarding handles auth at the end of its workflow; the subscribe path
-  // returns the user to /local via Stripe's success_url.
+  // Decide what to do once auth + subscription state have settled:
+  // 1. Signed-in + subscribed → dashboard (no effect needed, render handles it).
+  // 2. Signed-in + no sub + blob has a pending plan → fire Stripe checkout.
+  // 3. Signed-in + no sub + no pending plan → onboarding.
+  // 4. Signed-out → onboarding.
   useEffect(() => {
     if (authLoading || subLoading || fulfilling) return;
-    if (!user || !hasSubscription) {
+    if (kickoffFiredRef.current) return;
+
+    if (!user) {
       router.replace('/local/onboarding');
+      return;
     }
+
+    if (hasSubscription) return;
+
+    const blob = readOnboardingBlob();
+    const canResumeCheckout = Boolean(
+      blob &&
+        blob.mode === 'subscribe' &&
+        blob.pendingPlan &&
+        blob.city &&
+        blob.language &&
+        blob.topics.length > 0,
+    );
+
+    if (!canResumeCheckout) {
+      router.replace('/local/onboarding');
+      return;
+    }
+
+    kickoffFiredRef.current = true;
+    setKickoffState('running');
+    (async () => {
+      try {
+        const res = await fetch('/api/stripe/checkout', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            plan: blob!.pendingPlan,
+            city: blob!.city,
+            language: blob!.language,
+            topics: blob!.topics,
+            cityRequest: blob!.cityRequest,
+            referralCode: blob!.referralCode || undefined,
+          }),
+        });
+        const data = await res.json();
+        if (data.url) {
+          clearPendingPlanInStorage();
+          window.location.href = data.url;
+          return;
+        }
+        setKickoffState('error');
+        setKickoffError(data.error ?? "Something went wrong. Please try again.");
+      } catch {
+        setKickoffState('error');
+        setKickoffError("We couldn't reach checkout. Please try again.");
+      }
+    })();
   }, [authLoading, subLoading, fulfilling, user, hasSubscription, router]);
 
   useEffect(() => {
     if (hasSubscription) clearOnboardingBlob();
   }, [hasSubscription]);
 
-  if (authLoading || subLoading || fulfilling) {
+  if (authLoading || subLoading || fulfilling || kickoffState === 'running') {
+    const label = fulfilling
+      ? 'Setting up your subscription…'
+      : kickoffState === 'running'
+        ? 'Finishing your setup…'
+        : 'Loading…';
     return (
-      <div className="w-full min-h-[calc(100vh-56px)] bg-page flex items-center justify-center">
-        <p className="text-gray-400 text-[14px]">{fulfilling ? 'Setting up your subscription…' : 'Loading…'}</p>
+      <div className="w-full min-h-[calc(100vh-56px)] bg-page flex items-center justify-center px-5">
+        <div className="flex items-center gap-3 text-gray-500 text-[14px]">
+          <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+          {label}
+        </div>
+      </div>
+    );
+  }
+
+  if (kickoffState === 'error') {
+    return (
+      <div className="w-full min-h-[calc(100vh-56px)] bg-page flex items-center justify-center px-5 py-12">
+        <div className="w-full max-w-[400px] bg-white border border-gray-200 rounded-2xl shadow-sm p-8 text-center">
+          <h1 className="text-[20px] font-bold text-gray-950 mb-2 tracking-tight">
+            Checkout didn&apos;t start.
+          </h1>
+          <p
+            className="text-[14px] text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2 mb-6"
+            role="alert"
+            aria-live="polite"
+          >
+            {kickoffError ?? 'Something went wrong.'}
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              kickoffFiredRef.current = false;
+              setKickoffState('idle');
+              setKickoffError(null);
+              router.replace('/local/onboarding');
+            }}
+            className="inline-flex items-center justify-center min-h-[44px] px-6 text-[14.5px] font-semibold text-white bg-brand rounded-xl hover:bg-brand-hover transition-colors shadow-sm"
+          >
+            Back to plan selection
+          </button>
+        </div>
       </div>
     );
   }

--- a/components/local/onboarding/onboarding-wizard.tsx
+++ b/components/local/onboarding/onboarding-wizard.tsx
@@ -14,11 +14,7 @@ import { PlanStep } from "./plan-step";
 import { RequestStep } from "./request-step";
 import { AlternativeCitiesStep } from "./alternative-cities-step";
 import { OnboardingMode, OnboardingStep } from "./types";
-import {
-  ONBOARDING_STORAGE_KEY,
-  useOnboardingState,
-  type StoredOnboardingBlob,
-} from "./use-onboarding-state";
+import { useOnboardingState } from "./use-onboarding-state";
 
 const SUBSCRIBE_LABELS: Record<OnboardingStep, string> = {
   1: "City",
@@ -33,23 +29,6 @@ const REQUEST_LABELS: Record<1 | 2 | 3, string> = {
   3: "Other cities?",
 };
 
-// Writes to localStorage synchronously so the blob is flushed before we navigate
-// away to Stripe. Without this, the pending state-write effect may not run before
-// the browser unloads.
-function clearPendingPlanInStorage() {
-  if (typeof window === "undefined") return;
-  try {
-    const raw = window.localStorage.getItem(ONBOARDING_STORAGE_KEY);
-    if (!raw) return;
-    const blob = JSON.parse(raw) as StoredOnboardingBlob;
-    blob.pendingPlan = null;
-    blob.updatedAt = Date.now();
-    window.localStorage.setItem(ONBOARDING_STORAGE_KEY, JSON.stringify(blob));
-  } catch {
-    /* ignore */
-  }
-}
-
 export function OnboardingWizard() {
   const searchParams = useSearchParams();
   const urlRef = searchParams.get("ref");
@@ -62,7 +41,6 @@ export function OnboardingWizard() {
     state,
     step,
     mode,
-    pendingPlan,
     referralCode,
     updateState,
     setStep,
@@ -107,53 +85,12 @@ export function OnboardingWizard() {
     }
   }, [isHydrated, urlRef, referralCode, setReferralCode]);
 
-  // Auto-kickoff: after returning from Google OAuth, pick up where the user
-  // left off. Either resume the Stripe checkout for a pending plan, or submit
-  // the pending city request and advance to the alternatives step.
+  // Auto-kickoff (request mode only): after returning from Google OAuth with a
+  // pending city request, submit the waitlist entry and advance to the
+  // alternatives step. The subscribe-mode kickoff lives on /local now — plan
+  // CTA's OAuth redirects there directly.
   useEffect(() => {
     if (!isHydrated || !user || autoKickoffFiredRef.current) return;
-
-    const canAutoSubscribe =
-      mode === "subscribe" &&
-      Boolean(pendingPlan) &&
-      Boolean(state.city) &&
-      Boolean(state.language) &&
-      state.topics.length > 0;
-
-    if (canAutoSubscribe) {
-      autoKickoffFiredRef.current = true;
-      setAutoKickoffLabel("Finishing your setup…");
-      (async () => {
-        try {
-          const res = await fetch("/api/stripe/checkout", {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              plan: pendingPlan,
-              city: state.city,
-              language: state.language,
-              topics: state.topics,
-              cityRequest: state.cityRequest,
-              referralCode: referralCode || undefined,
-            }),
-          });
-          const data = await res.json();
-          if (data.url) {
-            // Clear pending plan so a back-button bounce to this page doesn't
-            // re-fire into checkout again. User can manually retry from step 4.
-            clearPendingPlanInStorage();
-            window.location.href = data.url;
-            return;
-          }
-          setAutoKickoffLabel(null);
-          setCheckoutError(data.error ?? "Something went wrong. Please try again.");
-        } catch {
-          setAutoKickoffLabel(null);
-          setCheckoutError("We couldn't reach checkout. Please try again.");
-        }
-      })();
-      return;
-    }
 
     const canAutoRequest =
       mode === "request" &&
@@ -183,7 +120,7 @@ export function OnboardingWizard() {
         }
       })();
     }
-  }, [isHydrated, user, mode, pendingPlan, state, step, referralCode, setStep]);
+  }, [isHydrated, user, mode, state, step, referralCode, setStep]);
 
   const totalSteps = mode === "request" ? 3 : 4;
   const stepLabel =
@@ -220,7 +157,7 @@ export function OnboardingWizard() {
         const { error: oauthError } = await supabase.auth.signInWithOAuth({
           provider: "google",
           options: {
-            redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent("/local/onboarding")}`,
+            redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent("/local")}`,
           },
         });
         if (oauthError) {


### PR DESCRIPTION
## Summary
Unauth user on step 4 → plan CTA → Google OAuth → redirect lands at **/local** (not /local/onboarding). /local detects the pending plan in the stored blob and fires the Stripe checkout directly.

End destination unchanged (Stripe success → /local dashboard), but post-OAuth the user never re-sees the onboarding wizard.

### Wizard
- Plan-CTA OAuth `redirectTo` changes from `/local/onboarding` → `/local`.
- Removes the subscribe branch from the wizard's auto-kickoff effect (request-mode branch stays — it still needs to advance to step 3 within the wizard).
- Drops the now-unused `clearPendingPlanInStorage` helper and `pendingPlan` destructure.

### /local
- On mount with settled auth + no subscription, reads the onboarding blob. If `mode==='subscribe'` + `pendingPlan` + city/language/topics complete, POSTs to `/api/stripe/checkout`, synchronously clears `pendingPlan` from localStorage, and `window.location.href`s to Stripe.
- Uses a ref to guarantee the kickoff fires exactly once per page load.
- New loading state ("Finishing your setup…") during kickoff; new retry card on failure that bounces back to `/local/onboarding`.

## Test plan
- [ ] Fresh unauth onboarding → step 4 Free → OAuth → **land at /local** with "Finishing your setup…" → Stripe → Stripe success → /local dashboard.
- [ ] Same for Pro with card entry.
- [ ] Back-button from Stripe onto /local → no kickoff (pendingPlan was cleared) → since `!hasSubscription`, redirect to `/local/onboarding` (user sees step 4 plan buttons).
- [ ] Request flow unchanged: step 2 Google sign-in → back to `/local/onboarding` → wizard auto-submits waitlist → step 3.
- [ ] Direct visit to /local while subscribed → dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)