### PR TITLE
Auto-heal subscriptions row on /local when Stripe 409s

### DIFF
--- a/app/local/page.tsx
+++ b/app/local/page.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/hooks/use-auth';
 import { useSubscription } from '@/hooks/use-subscription';
 import { SubscriptionDashboard } from '@/components/local/subscription-dashboard';
 import { fulfillCheckout } from '@/server-actions/fulfill-checkout';
+import { syncSubscriptionFromStripe } from '@/server-actions/sync-subscription';
 import {
   ONBOARDING_STORAGE_KEY,
   clearOnboardingBlob,
@@ -102,6 +103,18 @@ function NVLocalInner() {
             referralCode: blob!.referralCode || undefined,
           }),
         });
+
+        // Stripe already has an active subscription for this customer — the DB
+        // row is out of sync. Sync it from Stripe and re-render the dashboard.
+        if (res.status === 409) {
+          await syncSubscriptionFromStripe();
+          clearPendingPlanInStorage();
+          kickoffFiredRef.current = false;
+          setKickoffState('idle');
+          refetch();
+          return;
+        }
+
         const data = await res.json();
         if (data.url) {
           clearPendingPlanInStorage();

--- a/server-actions/sync-subscription.ts
+++ b/server-actions/sync-subscription.ts
@@ -1,0 +1,46 @@
+"use server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+import { getStripe } from "@/lib/stripe";
+
+// Reconciles the public.subscriptions row for the current authed user with
+// Stripe. Used when the DB is out of sync (row missing / stripe_status stale)
+// but Stripe still reports an active subscription — /api/stripe/checkout
+// 409s in that state, and we want /local to auto-heal rather than surface
+// an error card.
+export async function syncSubscriptionFromStripe(): Promise<
+  { ok: true } | { ok: false; error: string }
+> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return { ok: false, error: "Not authenticated" };
+
+  const stripe = getStripe();
+  const customers = await stripe.customers.list({ email: user.email, limit: 1 });
+  const customer = customers.data[0];
+  if (!customer) return { ok: false, error: "No Stripe customer" };
+
+  const subs = await stripe.subscriptions.list({
+    customer: customer.id,
+    status: "active",
+    limit: 1,
+  });
+  const sub = subs.data[0];
+  if (!sub) return { ok: false, error: "No active Stripe subscription" };
+
+  const admin = createSupabaseAdminClient();
+  const { error } = await admin.from("subscriptions").upsert(
+    {
+      contact: user.email,
+      stripe_customer_id: customer.id,
+      stripe_subscription_id: sub.id,
+      stripe_status: "active",
+    },
+    { onConflict: "contact" },
+  );
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}


### PR DESCRIPTION
## Summary
Fixes the "Checkout didn't start — You already have an active subscription" error card that appears on /local after OAuth when the `subscriptions` DB row is stale but Stripe still reports an active subscription.

### Root cause
1. After OAuth, /local fires POST /api/stripe/checkout.
2. The API queries Stripe directly, finds an existing active sub, returns 409.
3. /local treated any non-URL response as a generic error → error card.

### Fix
- **New:** `server-actions/sync-subscription.ts` — `syncSubscriptionFromStripe()` upserts the subscriptions row for the current user from Stripe (contact, stripe_customer_id, stripe_subscription_id, status='active').
- **Edit:** `app/local/page.tsx` — kickoff now branches on `res.status === 409`. Calls the sync, clears pendingPlan from storage, resets kickoff state, and `refetch()`s `useSubscription`. Since `getSubscriptionStatus` queries the DB (which the sync just wrote), `hasSubscription=true` on next tick → dashboard renders.

Happy-path (no existing sub) unchanged: POST returns `{url}`, we navigate to Stripe.

## Out of scope
Moving onboarding state off localStorage — deferred to a follow-up where the user will back it with Supabase directly.

## Test plan
- [ ] Set up state: Stripe has active sub for `user@example.com`, `public.subscriptions` has no row for that email. Go through onboarding → OAuth → /local. Expected: brief "Finishing your setup…" then dashboard renders. Verify the subscriptions row now exists with `stripe_status='active'`.
- [ ] Happy path regression: fresh user with no Stripe customer → finishes onboarding → /local → Stripe checkout URL → success → dashboard.
- [ ] `pnpm build` clean ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)