### PR TITLE
Fix four ship-blocking issues in subscription flow

### DIFF
--- a/app/local/page.tsx
+++ b/app/local/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense, useEffect, useState } from 'react';
+import { Suspense, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useAuth } from '@/hooks/use-auth';
 import { useSubscription } from '@/hooks/use-subscription';
@@ -13,21 +13,30 @@ function NVLocalInner() {
   const { user, isLoading: authLoading } = useAuth();
   const { hasSubscription, isLoading: subLoading, refetch } = useSubscription();
   const [fulfilling, setFulfilling] = useState(false);
+  const fulfilledSessionRef = useRef<string | null>(null);
 
   const isPostCheckout = searchParams.get('checkout') === 'success';
   const sessionId = searchParams.get('session_id');
 
-  // Post-Stripe fulfillment.
+  // Post-Stripe fulfillment. The sessionId-keyed ref guards against duplicate
+  // runs (React 18 StrictMode + any remount) since submitRegionWaitlist inside
+  // fulfillCheckout is not idempotent (emails admin, converts referrals).
   useEffect(() => {
     if (!isPostCheckout || !sessionId || !user) return;
+    if (fulfilledSessionRef.current === sessionId) return;
+    fulfilledSessionRef.current = sessionId;
     setFulfilling(true);
-    fulfillCheckout(sessionId)
-      .then((result) => {
-        if (result.success) refetch();
-      })
-      .finally(() => setFulfilling(false));
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isPostCheckout, sessionId, user]);
+    (async () => {
+      try {
+        const result = await fulfillCheckout(sessionId);
+        // Await refetch so hasSubscription is settled before we flip fulfilling
+        // off — otherwise the redirect effect can race and bounce the user.
+        if (result.success) await refetch();
+      } finally {
+        setFulfilling(false);
+      }
+    })();
+  }, [isPostCheckout, sessionId, user, refetch]);
 
   // Unauth or authed-without-subscription users get funnelled through onboarding.
   useEffect(() => {

--- a/components/local/onboarding/onboarding-wizard.tsx
+++ b/components/local/onboarding/onboarding-wizard.tsx
@@ -199,9 +199,20 @@ export function OnboardingWizard() {
         });
 
         // Stripe already has an active subscription for this customer. Sync
-        // the DB row from Stripe and send the user to their dashboard.
+        // the DB row from Stripe and send the user to their dashboard. If the
+        // sync fails, surface the error here — redirecting to /local blind
+        // would ping-pong the user back to this page.
         if (res.status === 409) {
-          await syncSubscriptionFromStripe();
+          const syncResult = await syncSubscriptionFromStripe();
+          if (!syncResult.ok) {
+            setCheckoutError(
+              syncResult.error ||
+                "You already have an active subscription, but we couldn't sync it. Contact hello@nextvoters.com.",
+            );
+            setIsRedirecting(false);
+            scrollToBottom();
+            return;
+          }
           router.replace("/local");
           return;
         }

--- a/hooks/use-subscription.ts
+++ b/hooks/use-subscription.ts
@@ -11,7 +11,7 @@ interface SubscriptionState {
   tier: 'pro' | 'free' | 'none';
 }
 
-export function useSubscription(): SubscriptionState & { refetch: () => void } {
+export function useSubscription(): SubscriptionState & { refetch: () => Promise<void> } {
   const [state, setState] = useState<SubscriptionState>({
     isPro: false,
     isAuthenticated: false,
@@ -20,11 +20,10 @@ export function useSubscription(): SubscriptionState & { refetch: () => void } {
     tier: 'none',
   });
 
-  const refetch = useCallback(() => {
+  const refetch = useCallback(async () => {
     setState((prev) => ({ ...prev, isLoading: true }));
-    getSubscriptionStatus().then((result) => {
-      setState({ ...result, isLoading: false });
-    });
+    const result = await getSubscriptionStatus();
+    setState({ ...result, isLoading: false });
   }, []);
 
   useEffect(() => {

--- a/server-actions/fulfill-checkout.ts
+++ b/server-actions/fulfill-checkout.ts
@@ -53,6 +53,19 @@ export async function fulfillCheckout(sessionId: string): Promise<{ success: boo
 
   const admin = createSupabaseAdminClient()
 
+  // Idempotency: if we've already fulfilled this exact session for this user,
+  // short-circuit so we don't re-send admin emails or re-convert referrals
+  // (submitRegionWaitlist below is not idempotent).
+  const { data: existingRow } = await admin
+    .from("subscriptions")
+    .select("stripe_subscription_id")
+    .eq("contact", user.email)
+    .maybeSingle()
+
+  if (existingRow?.stripe_subscription_id === session.subscription) {
+    return { success: true }
+  }
+
   const upsertPayload: Record<string, string> = {
     contact: user.email,
     stripe_customer_id: session.customer as string,

--- a/server-actions/sync-subscription.ts
+++ b/server-actions/sync-subscription.ts
@@ -9,9 +9,10 @@ import { getStripe } from "@/lib/stripe";
 // but Stripe still reports an active subscription — /api/stripe/checkout
 // 409s in that state, and we want /local to auto-heal rather than surface
 // an error card.
-export async function syncSubscriptionFromStripe(): Promise<
-  { ok: true } | { ok: false; error: string }
-> {
+export async function syncSubscriptionFromStripe(): Promise<{
+  ok: boolean;
+  error?: string;
+}> {
   const supabase = await createSupabaseServerClient();
   const {
     data: { user },


### PR DESCRIPTION
## Summary
Addresses the four critical issues surfaced by the code review of PRs #84–#86.

### C1 — Fulfillment race on /local
**Problem:** \`useSubscription.refetch\` was \`() => void\`, so \`/local\`'s post-checkout effect cleared \`fulfilling\` before \`hasSubscription\` settled. The redirect effect could fire in that gap and bounce the user to \`/local/onboarding\`.

**Fix:**
- \`hooks/use-subscription.ts\` — \`refetch\` now returns \`Promise<void>\`.
- \`app/local/page.tsx\` — effect is an async IIFE with \`try/finally\`; \`await refetch()\` completes before \`setFulfilling(false)\`.

### C2 — Non-idempotent \`fulfillCheckout\`
**Problem:** React 18 StrictMode + any remount could re-run \`fulfillCheckout(sessionId)\`. Its \`submitRegionWaitlist\` side-effect emails admin and converts referrals — not idempotent.

**Fix:**
- \`app/local/page.tsx\` — \`fulfilledSessionRef\` keyed on sessionId guards the effect.
- \`server-actions/fulfill-checkout.ts\` — short-circuits with \`{ success: true }\` when \`subscriptions.stripe_subscription_id === session.subscription\`. Belt-and-suspenders.

### C3/C4 — Wizard 409 ping-pong + discarded sync result
**Problem:** On 409, wizard called \`syncSubscriptionFromStripe()\` then blindly \`router.replace('/local')\`. If sync failed silently, \`/local\` saw no sub and bounced back to \`/local/onboarding\` → wizard re-fired 409 → infinite loop.

**Fix:**
- \`components/local/onboarding/onboarding-wizard.tsx\` — checks \`syncResult.ok\`; surfaces \`syncResult.error\` inline (with a fallback message pointing at support) when sync fails, no navigation.
- \`server-actions/sync-subscription.ts\` — return type flattened from discriminated union to \`{ ok: boolean; error?: string }\` to sidestep a TS 5.0.4 narrowing quirk inside async server-action call sites.

## Test plan
- [ ] Post-Stripe-success flow: \`/local?checkout=success&session_id=X\` → "Setting up your subscription…" until refetch resolves → dashboard renders (no flash to onboarding).
- [ ] Hit \`/local?checkout=success&session_id=X\` twice in quick succession (browser refresh / StrictMode): only one fulfillment runs; subsequent calls short-circuit.
- [ ] 409 path, sync succeeds: dashboard renders (existing behavior, regression-tested).
- [ ] 409 path, sync fails: user sees inline error in wizard, stays on step 4, no redirect loop.
- [ ] \`pnpm build\` clean ✅.

## Out of scope (deferred per user)
Moderate issues from the review (dead \`pendingPlan\`, broad auto-kickoff deps, pre-OAuth setTimeout brittleness, duplicated upsert between \`fulfillCheckout\` / \`syncSubscriptionFromStripe\`, etc.) get cleaned up as part of tomorrow's Supabase-backed onboarding-state migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)