### PR TITLE
Make landing page newsletter-first with city pre-fill into onboarding

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,242 +1,14 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
-import { useRouter } from "next/navigation";
-import { MessageSquare, Layers, BookOpen, ArrowRight } from "lucide-react";
-import PreferenceSelector from "@/components/preference-selector";
+import { MapPin, Layers, BookOpen, ArrowRight } from "lucide-react";
 import ClientMountWrapper from "@/components/client-mount-wrapper";
-
-type AnalyticsCounts = {
-  requestCount: number;
-  responseCount: number;
-};
-
-type ExampleQuestion = {
-  tag: string;
-  tagTone: "brand" | "neutral" | "muted";
-  title: string;
-  blurb: string;
-};
-
-const EXAMPLE_QUESTIONS: ExampleQuestion[] = [
-  {
-    tag: "Federal",
-    tagTone: "brand",
-    title: "What's actually in the new infrastructure bill?",
-    blurb: "Break down the spending, the tradeoffs, and who gets what.",
-  },
-  {
-    tag: "Local",
-    tagTone: "neutral",
-    title: "How does my city's zoning policy affect housing?",
-    blurb: "See the rules, the debate, and the downstream effects.",
-  },
-  {
-    tag: "Rights",
-    tagTone: "muted",
-    title: "What are the current voter ID requirements in my state?",
-    blurb: "Know what you need before you show up at the polls.",
-  },
-  {
-    tag: "Economy",
-    tagTone: "neutral",
-    title: "How do tariffs change consumer prices?",
-    blurb: "Trace the line from policy to your grocery bill.",
-  },
-  {
-    tag: "Ballot",
-    tagTone: "brand",
-    title: "What does this ballot measure really do?",
-    blurb: "Cut past the marketing and read what's on the page.",
-  },
-  {
-    tag: "Civics",
-    tagTone: "muted",
-    title: "How does a bill actually become law?",
-    blurb: "The short version, with the parts that actually matter.",
-  },
-];
-
-const tagClasses: Record<ExampleQuestion["tagTone"], string> = {
-  brand: "bg-red-50 text-red-700 ring-1 ring-red-100",
-  neutral: "bg-gray-900 text-white",
-  muted: "bg-gray-100 text-gray-700 ring-1 ring-gray-200",
-};
+import { NewsletterHero } from "@/components/home/newsletter-hero";
 
 const Home = () => {
-  const router = useRouter();
-  const [message, setMessage] = useState("");
-  const [analytics, setAnalytics] = useState<AnalyticsCounts | null>(null);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const fetchAnalytics = async () => {
-      try {
-        const res = await fetch("/api/analytics", { cache: "no-store" });
-        if (!res.ok) return;
-        const data = (await res.json()) as AnalyticsCounts;
-        if (cancelled) return;
-        setAnalytics(data);
-      } catch {
-        // analytics isn't critical for page function
-      }
-    };
-
-    fetchAnalytics();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  const goToChat = (q?: string) => {
-    const query = (q ?? message).trim();
-    if (query) {
-      router.push(`/chat?message=${encodeURIComponent(query)}`);
-    } else {
-      router.push("/chat");
-    }
-  };
-
-  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-    if (event.key === "Enter") goToChat();
-  };
-
   return (
     <ClientMountWrapper className="min-h-screen bg-page">
       <div className="w-full font-plus-jakarta-sans">
-        {/* ───────────── Hero ───────────── */}
-        <section className="relative overflow-hidden">
-          {/* Radial accent glow */}
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-x-0 -top-32 h-[620px] opacity-70"
-            style={{
-              background:
-                "radial-gradient(60% 50% at 50% 40%, rgba(235, 34, 64, 0.18) 0%, rgba(235, 34, 64, 0.06) 45%, rgba(235, 34, 64, 0) 78%)",
-            }}
-          />
-          {/* Subtle grid */}
-          <div
-            aria-hidden
-            className="pointer-events-none absolute inset-0 opacity-[0.35]"
-            style={{
-              backgroundImage:
-                "linear-gradient(rgba(17,17,17,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(17,17,17,0.05) 1px, transparent 1px)",
-              backgroundSize: "48px 48px",
-              maskImage:
-                "radial-gradient(ellipse at center top, black 40%, transparent 80%)",
-              WebkitMaskImage:
-                "radial-gradient(ellipse at center top, black 40%, transparent 80%)",
-            }}
-          />
-
-          <div className="relative max-w-[1100px] mx-auto px-6 pt-20 pb-16 md:pt-28 md:pb-24">
-            <div className="flex justify-center mb-8">
-              <div className="inline-flex items-center gap-3 rounded-full bg-gray-950 text-white ring-1 ring-white/10 shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)] pl-3 pr-4 py-2 text-[13px] font-medium">
-                {/* Item 1: Google for Nonprofits */}
-                <span className="inline-flex items-center gap-2">
-                  <span className="inline-flex items-center justify-center h-5 w-5 rounded bg-white text-gray-950">
-                    <svg viewBox="0 0 24 24" className="h-3 w-3" aria-hidden>
-                      <path
-                        fill="currentColor"
-                        d="M21.35 11.1H12v2.98h5.35c-.23 1.47-1.8 4.32-5.35 4.32-3.22 0-5.85-2.67-5.85-5.96S8.78 6.48 12 6.48c1.83 0 3.06.78 3.76 1.45l2.56-2.47C16.88 4.05 14.63 3 12 3 6.98 3 3 6.98 3 12s3.98 9 9 9c5.19 0 8.63-3.65 8.63-8.78 0-.59-.06-1.04-.13-1.5z"
-                      />
-                    </svg>
-                  </span>
-                  <span className="whitespace-nowrap">Google for Nonprofits</span>
-                </span>
-
-                <span aria-hidden className="h-4 w-px bg-white/20" />
-
-                {/* Item 2: Nonpartisan & cited */}
-                <span className="inline-flex items-center gap-2">
-                  <span className="inline-flex items-center justify-center h-5 w-5 rounded bg-white text-gray-950">
-                    <svg viewBox="0 0 24 24" className="h-3 w-3" aria-hidden>
-                      <path
-                        fill="currentColor"
-                        d="M12 2 4 5v6c0 5 3.4 9.5 8 11 4.6-1.5 8-6 8-11V5l-8-3zm-1 14.17-3.59-3.58L6 14l5 5 9-9-1.41-1.42L11 16.17z"
-                      />
-                    </svg>
-                  </span>
-                  <span className="whitespace-nowrap">Nonpartisan &amp; cited</span>
-                </span>
-              </div>
-            </div>
-
-            <h1 className="text-center text-[44px] sm:text-[56px] md:text-[68px] font-bold tracking-tight text-gray-900 leading-[1.05] max-w-[900px] mx-auto">
-              Understand policy the way it actually{" "}
-              <span className="relative inline-block">
-                <span className="relative z-10">works.</span>
-                <span
-                  aria-hidden
-                  className="absolute inset-x-0 bottom-1 md:bottom-2 h-2 md:h-3 bg-red-200/70 -z-0 rounded"
-                />
-              </span>
-            </h1>
-
-            <p className="mt-6 text-center text-[17px] md:text-[19px] text-gray-600 leading-relaxed max-w-2xl mx-auto">
-              Ask any civic question and get clear, multi-perspective answers
-              with citations — not spin, not jargon, not a feed.
-            </p>
-
-            {/* Search card */}
-            <div className="mt-10 max-w-[720px] mx-auto">
-              <div className="group relative rounded-2xl bg-white border border-gray-200 shadow-[0_1px_0_rgba(17,17,17,0.04),0_20px_40px_-20px_rgba(17,17,17,0.12)] p-2.5 pr-2.5 transition-shadow focus-within:shadow-[0_0_0_4px_rgba(235,34,64,0.08),0_20px_40px_-20px_rgba(17,17,17,0.18)]">
-                <div className="flex items-stretch gap-2">
-                  <div className="flex-1 relative">
-                    <input
-                      type="text"
-                      placeholder="e.g. What does Bill C-27 actually do?"
-                      className="w-full h-12 pl-4 pr-3 text-[15px] text-gray-900 bg-transparent border-0 outline-none placeholder:text-gray-400"
-                      onChange={(e) => setMessage(e.target.value)}
-                      onKeyDown={handleKeyDown}
-                    />
-                  </div>
-                  <button
-                    type="button"
-                    onClick={() => goToChat()}
-                    className="inline-flex items-center gap-2 rounded-xl bg-red-500 hover:bg-red-600 active:bg-red-700 text-white text-[14px] font-semibold px-4 md:px-5 h-12 transition-colors shadow-sm"
-                  >
-                    <span className="hidden sm:inline">Ask</span>
-                    <ArrowRight className="w-4 h-4" />
-                  </button>
-                </div>
-                <div className="flex items-center justify-between gap-4 mt-2 pl-1.5 pr-1">
-                  <div className="min-w-0 flex-1">
-                    <PreferenceSelector />
-                  </div>
-                  <span className="shrink-0 text-[12.5px] text-gray-500">
-                    <span className="font-semibold text-gray-900">
-                      {analytics?.responseCount?.toLocaleString() ?? "—"}
-                    </span>{" "}
-                    answers delivered
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            {/* Dual CTAs */}
-            <div className="mt-8 flex flex-col sm:flex-row gap-3 justify-center items-center">
-              <a
-                href="/chat"
-                className="inline-flex items-center justify-center gap-2 rounded-lg bg-gray-900 hover:bg-black text-white text-[15px] font-semibold px-6 h-12 transition-colors w-full sm:w-auto"
-              >
-                Start asking questions
-                <ArrowRight className="w-4 h-4" />
-              </a>
-              <a
-                href="/local"
-                className="inline-flex items-center justify-center gap-2 rounded-lg bg-white hover:bg-gray-50 text-gray-900 text-[15px] font-semibold px-6 h-12 border border-gray-200 transition-colors w-full sm:w-auto"
-              >
-                Get weekly local alerts
-              </a>
-            </div>
-            <p className="mt-4 text-center text-[12.5px] text-gray-500">
-              Free. Nonpartisan. No newsletter spam.
-            </p>
-          </div>
-        </section>
+        <NewsletterHero />
 
         {/* ───────────── Supporters strip ───────────── */}
         <section className="border-y border-gray-200/80 bg-white/60 backdrop-blur">
@@ -259,55 +31,6 @@ const Home = () => {
           </div>
         </section>
 
-        {/* ───────────── Example questions grid ───────────── */}
-        <section className="py-20 md:py-28">
-          <div className="max-w-[1100px] mx-auto px-6">
-            <div className="flex flex-col md:flex-row md:items-end md:justify-between gap-4 mb-10 md:mb-14">
-              <div>
-                <p className="text-[11.5px] tracking-[0.14em] uppercase text-red-600 font-semibold mb-3">
-                  Try a real question
-                </p>
-                <h2 className="text-[32px] md:text-[40px] font-bold text-gray-900 tracking-tight leading-[1.1] max-w-[640px]">
-                  Every question gets a grounded, sourced answer.
-                </h2>
-              </div>
-              <a
-                href="/chat"
-                className="hidden md:inline-flex items-center gap-1.5 text-[14px] font-semibold text-gray-900 hover:text-red-600 transition-colors"
-              >
-                Browse the chat <ArrowRight className="w-4 h-4" />
-              </a>
-            </div>
-
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
-              {EXAMPLE_QUESTIONS.map((q) => (
-                <button
-                  key={q.title}
-                  type="button"
-                  onClick={() => goToChat(q.title)}
-                  className="group relative text-left rounded-xl bg-white border border-gray-200 p-6 hover:border-gray-300 hover:shadow-[0_10px_30px_-12px_rgba(17,17,17,0.12)] transition-all duration-200"
-                >
-                  <span
-                    className={`inline-flex items-center text-[11px] font-semibold uppercase tracking-wider px-2 py-1 rounded-md ${tagClasses[q.tagTone]}`}
-                  >
-                    {q.tag}
-                  </span>
-                  <h3 className="mt-4 text-[17px] font-semibold text-gray-900 leading-snug group-hover:text-red-600 transition-colors">
-                    {q.title}
-                  </h3>
-                  <p className="mt-2 text-[14px] text-gray-600 leading-relaxed">
-                    {q.blurb}
-                  </p>
-                  <span className="mt-5 inline-flex items-center gap-1.5 text-[13px] font-semibold text-gray-500 group-hover:text-red-600 transition-colors">
-                    Ask this
-                    <ArrowRight className="w-3.5 h-3.5 transition-transform group-hover:translate-x-0.5" />
-                  </span>
-                </button>
-              ))}
-            </div>
-          </div>
-        </section>
-
         {/* ───────────── How it works ───────────── */}
         <section className="relative py-20 md:py-28 bg-white border-y border-gray-200/80">
           <div className="max-w-[1100px] mx-auto px-6">
@@ -323,19 +46,19 @@ const Home = () => {
             <ol className="grid grid-cols-1 md:grid-cols-3 gap-8 md:gap-12">
               {[
                 {
-                  icon: MessageSquare,
-                  title: "Ask any civic question.",
-                  body: "From federal bills to local zoning to the measure on page 3 of your ballot — if it's civic, it's fair game.",
+                  icon: MapPin,
+                  title: "Pick your city.",
+                  body: "Tell us where you live. We follow council meetings, bylaws, and local bills for cities across North America.",
                 },
                 {
                   icon: Layers,
-                  title: "Get every perspective.",
-                  body: "Answers are generated per political party in parallel, so you see how each side frames it — side-by-side, in plain English.",
+                  title: "We summarize what matters.",
+                  body: "Every week, our team distills the week's most consequential local decisions into plain-English briefs — nonpartisan, never spun.",
                 },
                 {
                   icon: BookOpen,
-                  title: "Dig into the sources.",
-                  body: "Every claim is backed by citations from official party platforms and government documents. Trust, then verify.",
+                  title: "Read it in five minutes.",
+                  body: "A single, clean email lands in your inbox each week. Every claim is backed by citations to official government documents.",
                 },
               ].map((step, i) => {
                 const Icon = step.icon;
@@ -425,25 +148,19 @@ const Home = () => {
           />
           <div className="relative max-w-[1100px] mx-auto px-6 py-20 md:py-28 text-center">
             <h2 className="text-[32px] md:text-[48px] font-bold text-white tracking-tight leading-[1.05] max-w-[760px] mx-auto">
-              Informed voting shouldn&apos;t require a law degree.
+              Staying informed shouldn&apos;t require a law degree.
             </h2>
             <p className="mt-5 text-[16px] md:text-[18px] text-gray-300 leading-relaxed max-w-[560px] mx-auto">
-              Ask a question now — or get a free weekly digest of what&apos;s
-              happening in your city.
+              Get a free weekly digest of what&apos;s happening in your city —
+              nonpartisan, cited, and in your inbox by Sunday.
             </p>
-            <div className="mt-10 flex flex-col sm:flex-row gap-3 justify-center items-center">
+            <div className="mt-10 flex justify-center">
               <a
-                href="/chat"
+                href="/local/onboarding"
                 className="inline-flex items-center justify-center gap-2 rounded-lg bg-red-500 hover:bg-red-600 text-white text-[15px] font-semibold px-7 h-12 transition-colors w-full sm:w-auto shadow-lg shadow-red-900/30"
               >
-                Ask your first question
+                Subscribe to your city&apos;s weekly update
                 <ArrowRight className="w-4 h-4" />
-              </a>
-              <a
-                href="/local"
-                className="inline-flex items-center justify-center gap-2 rounded-lg bg-white/10 hover:bg-white/15 text-white text-[15px] font-semibold px-7 h-12 border border-white/15 transition-colors w-full sm:w-auto backdrop-blur"
-              >
-                Subscribe to alerts
               </a>
             </div>
           </div>

--- a/components/home/newsletter-hero.tsx
+++ b/components/home/newsletter-hero.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { ArrowRight } from "lucide-react";
+import { CityAutocomplete } from "@/components/local/city-autocomplete";
+
+export function NewsletterHero() {
+  const router = useRouter();
+  const [city, setCity] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = () => {
+    setError(null);
+    const trimmed = city.trim();
+    if (!trimmed) {
+      setError("Please enter your city.");
+      return;
+    }
+    router.push(`/local/onboarding?city=${encodeURIComponent(trimmed)}`);
+  };
+
+  return (
+    <section className="relative overflow-hidden">
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 -top-32 h-[620px] opacity-70"
+        style={{
+          background:
+            "radial-gradient(60% 50% at 50% 40%, rgba(235, 34, 64, 0.18) 0%, rgba(235, 34, 64, 0.06) 45%, rgba(235, 34, 64, 0) 78%)",
+        }}
+      />
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-[0.35]"
+        style={{
+          backgroundImage:
+            "linear-gradient(rgba(17,17,17,0.05) 1px, transparent 1px), linear-gradient(90deg, rgba(17,17,17,0.05) 1px, transparent 1px)",
+          backgroundSize: "48px 48px",
+          maskImage:
+            "radial-gradient(ellipse at center top, black 40%, transparent 80%)",
+          WebkitMaskImage:
+            "radial-gradient(ellipse at center top, black 40%, transparent 80%)",
+        }}
+      />
+
+      <div className="relative max-w-[1100px] mx-auto px-6 pt-20 pb-16 md:pt-28 md:pb-24">
+        <div className="flex justify-center mb-8">
+          <div className="inline-flex items-center gap-3 rounded-full bg-gray-950 text-white ring-1 ring-white/10 shadow-[0_10px_30px_-12px_rgba(0,0,0,0.35)] pl-3 pr-4 py-2 text-[13px] font-medium">
+            <span className="inline-flex items-center gap-2">
+              <span className="inline-flex items-center justify-center h-5 w-5 rounded bg-white text-gray-950">
+                <svg viewBox="0 0 24 24" className="h-3 w-3" aria-hidden>
+                  <path
+                    fill="currentColor"
+                    d="M21.35 11.1H12v2.98h5.35c-.23 1.47-1.8 4.32-5.35 4.32-3.22 0-5.85-2.67-5.85-5.96S8.78 6.48 12 6.48c1.83 0 3.06.78 3.76 1.45l2.56-2.47C16.88 4.05 14.63 3 12 3 6.98 3 3 6.98 3 12s3.98 9 9 9c5.19 0 8.63-3.65 8.63-8.78 0-.59-.06-1.04-.13-1.5z"
+                  />
+                </svg>
+              </span>
+              <span className="whitespace-nowrap">Google for Nonprofits</span>
+            </span>
+
+            <span aria-hidden className="h-4 w-px bg-white/20" />
+
+            <span className="inline-flex items-center gap-2">
+              <span className="inline-flex items-center justify-center h-5 w-5 rounded bg-white text-gray-950">
+                <svg viewBox="0 0 24 24" className="h-3 w-3" aria-hidden>
+                  <path
+                    fill="currentColor"
+                    d="M12 2 4 5v6c0 5 3.4 9.5 8 11 4.6-1.5 8-6 8-11V5l-8-3zm-1 14.17-3.59-3.58L6 14l5 5 9-9-1.41-1.42L11 16.17z"
+                  />
+                </svg>
+              </span>
+              <span className="whitespace-nowrap">Nonpartisan &amp; cited</span>
+            </span>
+          </div>
+        </div>
+
+        <h1 className="text-center text-[44px] sm:text-[56px] md:text-[68px] font-bold tracking-tight text-gray-900 leading-[1.05] max-w-[900px] mx-auto">
+          Local civic updates, delivered{" "}
+          <span className="relative inline-block">
+            <span className="relative z-10">weekly.</span>
+            <span
+              aria-hidden
+              className="absolute inset-x-0 bottom-1 md:bottom-2 h-2 md:h-3 bg-red-200/70 -z-0 rounded"
+            />
+          </span>
+        </h1>
+
+        <p className="mt-6 text-center text-[17px] md:text-[19px] text-gray-600 leading-relaxed max-w-2xl mx-auto">
+          Nonpartisan summaries of council meetings, bylaws, and local bills —
+          in your inbox, every week. Just enter your city to start.
+        </p>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSubmit();
+          }}
+          className="mt-10 max-w-[640px] mx-auto"
+          noValidate
+        >
+          <div className="relative rounded-2xl bg-white border border-gray-200 shadow-[0_1px_0_rgba(17,17,17,0.04),0_20px_40px_-20px_rgba(17,17,17,0.12)] p-1.5 transition-shadow focus-within:shadow-[0_0_0_4px_rgba(235,34,64,0.08),0_20px_40px_-20px_rgba(17,17,17,0.18)]">
+            <div className="flex items-stretch gap-2">
+              <div className="flex-1 min-w-0">
+                <CityAutocomplete
+                  variant="hero"
+                  value={city}
+                  onValueChange={(next) => {
+                    setCity(next);
+                    setError(null);
+                  }}
+                  onSubmit={handleSubmit}
+                  placeholder="e.g. Vancouver"
+                  inputId="home-city"
+                />
+              </div>
+              <button
+                type="submit"
+                disabled={!city.trim()}
+                className="shrink-0 inline-flex items-center justify-center gap-1.5 rounded-xl bg-red-500 hover:bg-red-600 active:bg-red-700 disabled:opacity-50 disabled:cursor-not-allowed text-white text-[14px] sm:text-[14.5px] font-semibold px-4 sm:px-5 h-12 transition-colors shadow-sm"
+              >
+                <span>Subscribe</span>
+                <ArrowRight className="w-4 h-4" />
+              </button>
+            </div>
+          </div>
+          {error && (
+            <p
+              className="mt-3 text-center text-[13px] text-red-700"
+              role="alert"
+              aria-live="polite"
+            >
+              {error}
+            </p>
+          )}
+          <p className="mt-4 text-center text-[12.5px] text-gray-500">
+            Free. Nonpartisan. No newsletter spam.
+          </p>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/components/local/city-autocomplete.tsx
+++ b/components/local/city-autocomplete.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { MapPin, Search } from "lucide-react";
+
+interface PhotonSuggestion {
+  label: string;
+  name: string;
+  country: string | null;
+}
+
+interface CityAutocompleteProps {
+  value: string;
+  onValueChange: (value: string, pickedFromSuggestions: boolean) => void;
+  onSubmit?: () => void;
+  disabled?: boolean;
+  placeholder?: string;
+  inputId?: string;
+  variant?: "wizard" | "hero";
+  autoFocus?: boolean;
+}
+
+export function CityAutocomplete({
+  value,
+  onValueChange,
+  onSubmit,
+  disabled = false,
+  placeholder = "Start typing a city name…",
+  inputId,
+  variant = "wizard",
+  autoFocus = false,
+}: CityAutocompleteProps) {
+  const [suggestions, setSuggestions] = useState<PhotonSuggestion[]>([]);
+  const [suggestionsLoading, setSuggestionsLoading] = useState(false);
+  const [suggestionsOpen, setSuggestionsOpen] = useState(false);
+  const [pickedCity, setPickedCity] = useState("");
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const trimmed = value.trim();
+    if (trimmed.length < 2 || trimmed === pickedCity) {
+      setSuggestions([]);
+      return;
+    }
+    const controller = new AbortController();
+    const timer = setTimeout(async () => {
+      setSuggestionsLoading(true);
+      try {
+        const res = await fetch(
+          `/api/cities/search?q=${encodeURIComponent(trimmed)}`,
+          { signal: controller.signal },
+        );
+        if (!res.ok) {
+          setSuggestions([]);
+          return;
+        }
+        const data = (await res.json()) as { cities?: PhotonSuggestion[] };
+        setSuggestions(data.cities ?? []);
+      } catch (err) {
+        if ((err as Error).name !== "AbortError") setSuggestions([]);
+      } finally {
+        setSuggestionsLoading(false);
+      }
+    }, 250);
+    return () => {
+      controller.abort();
+      clearTimeout(timer);
+    };
+  }, [value, pickedCity]);
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setSuggestionsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handlePick = (name: string) => {
+    setPickedCity(name);
+    setSuggestions([]);
+    setSuggestionsOpen(false);
+    onValueChange(name, true);
+  };
+
+  const hasDropdown =
+    suggestionsOpen && (suggestions.length > 0 || suggestionsLoading);
+
+  const isHero = variant === "hero";
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <div
+        className={
+          isHero
+            ? "flex items-stretch"
+            : "flex items-stretch border border-gray-200 rounded-xl overflow-hidden bg-white focus-within:border-brand focus-within:ring-2 focus-within:ring-brand/20"
+        }
+      >
+        <div
+          className={
+            isHero
+              ? "flex items-center pl-4 pr-2"
+              : "flex items-center justify-center px-3 border-r border-gray-200 bg-gray-50"
+          }
+        >
+          <Search
+            className={
+              isHero
+                ? "h-4 w-4 text-gray-500"
+                : "h-4 w-4 text-gray-400"
+            }
+            aria-hidden="true"
+          />
+        </div>
+        <input
+          id={inputId}
+          type="text"
+          autoComplete="off"
+          autoFocus={autoFocus}
+          placeholder={placeholder}
+          value={value}
+          onChange={(e) => {
+            setPickedCity("");
+            setSuggestionsOpen(true);
+            onValueChange(e.target.value, false);
+          }}
+          onFocus={() => setSuggestionsOpen(true)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              onSubmit?.();
+            }
+            if (e.key === "Escape") {
+              setSuggestionsOpen(false);
+            }
+          }}
+          className={
+            isHero
+              ? "flex-1 min-w-0 pr-2 text-[15.5px] sm:text-[16px] text-gray-950 placeholder:text-gray-400 focus:outline-none bg-transparent h-12"
+              : "flex-1 min-w-0 px-3 py-3 text-[14.5px] text-gray-950 placeholder:text-gray-400 focus:outline-none"
+          }
+          disabled={disabled}
+        />
+      </div>
+
+      {hasDropdown && (
+        <ul
+          className="absolute left-0 right-0 top-full z-[60] mt-1 max-h-[320px] overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg"
+          role="listbox"
+        >
+          {suggestions.length === 0 && suggestionsLoading && (
+            <li className="px-3 py-3 text-[13px] text-gray-400">Searching…</li>
+          )}
+          {suggestions.map((s) => (
+            <li
+              key={s.label}
+              role="option"
+              aria-selected={pickedCity === s.name}
+            >
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={() => handlePick(s.name)}
+                className="w-full flex items-start gap-2 text-left px-3 py-2.5 text-[13.5px] hover:bg-gray-50"
+              >
+                <MapPin
+                  className="w-4 h-4 text-gray-400 shrink-0 mt-0.5"
+                  aria-hidden="true"
+                />
+                <span>
+                  <span className="font-semibold text-gray-900">{s.name}</span>
+                  {s.label !== s.name && (
+                    <span className="text-gray-500">
+                      {" — "}
+                      {s.label.replace(`${s.name}, `, "")}
+                    </span>
+                  )}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/local/onboarding/onboarding-wizard.tsx
+++ b/components/local/onboarding/onboarding-wizard.tsx
@@ -6,7 +6,6 @@ import { ArrowLeft, Loader2 } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
 import { getSupportedCities } from "@/server-actions/get-supported-cities";
-import { submitRegionWaitlist } from "@/server-actions/request-region";
 import { syncSubscriptionFromStripe } from "@/server-actions/sync-subscription";
 import { CityStep } from "./city-step";
 import { LanguageStep } from "./language-step";
@@ -59,10 +58,8 @@ export function OnboardingWizard() {
   );
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [preAuthNotice, setPreAuthNotice] = useState<string | null>(null);
-  const [autoKickoffLabel, setAutoKickoffLabel] = useState<string | null>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
   const isFirstStepChangeRef = useRef(true);
-  const autoKickoffFiredRef = useRef(false);
   const hydratedFromCityParamRef = useRef(false);
 
   useEffect(() => {
@@ -86,7 +83,9 @@ export function OnboardingWizard() {
   }, [urlRef, referralCode, setReferralCode]);
 
   // Pre-fill city from `?city=` (e.g., from the landing-page hero). Runs once
-  // after cities load, so the supported-match check is valid.
+  // after cities load so the supported-match check is valid. The URL param is
+  // stripped after hydration so a remount (auth flip, back-nav) can't re-fire
+  // this effect and clobber user progress past step 2.
   useEffect(() => {
     if (citiesLoading || hydratedFromCityParamRef.current) return;
     if (!urlCity) return;
@@ -106,43 +105,17 @@ export function OnboardingWizard() {
       setMode("request");
       setStep(2);
     }
-  }, [citiesLoading, supportedCities, urlCity, updateState, setMode, setStep]);
 
-  // Auto-kickoff (request mode only): after returning from Google OAuth with a
-  // pending city request, submit the waitlist entry and advance to the
-  // alternatives step.
-  useEffect(() => {
-    if (!user || autoKickoffFiredRef.current) return;
-
-    const canAutoRequest =
-      mode === "request" &&
-      Boolean(state.cityRequest?.city) &&
-      step === 2;
-
-    if (canAutoRequest) {
-      autoKickoffFiredRef.current = true;
-      setAutoKickoffLabel(`Adding ${state.cityRequest!.city} to your waitlist…`);
-      (async () => {
-        try {
-          const result = await submitRegionWaitlist({
-            city: state.cityRequest!.city,
-            voterEmail: user.email,
-            referralCode: referralCode || undefined,
-          });
-          if (result.ok === false) {
-            setAutoKickoffLabel(null);
-            setCheckoutError(result.error);
-            return;
-          }
-          setStep(3);
-          setAutoKickoffLabel(null);
-        } catch {
-          setAutoKickoffLabel(null);
-          setCheckoutError("We couldn't save your request. Please try again.");
-        }
-      })();
-    }
-  }, [user, mode, state, step, referralCode, setStep]);
+    router.replace("/local/onboarding", { scroll: false });
+  }, [
+    citiesLoading,
+    supportedCities,
+    urlCity,
+    updateState,
+    setMode,
+    setStep,
+    router,
+  ]);
 
   const totalSteps = mode === "request" ? 3 : 4;
   const stepLabel =
@@ -363,34 +336,23 @@ export function OnboardingWizard() {
         )}
       </div>
 
-      {(preAuthNotice || autoKickoffLabel) && (
+      {preAuthNotice && (
         <div
           className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 px-5 animate-in fade-in duration-150"
           role="status"
           aria-live="polite"
         >
           <div className="w-full max-w-[380px] bg-white rounded-2xl shadow-xl p-6 text-center">
-            {preAuthNotice ? (
-              <>
-                <p className="text-[17px] font-bold text-gray-950 tracking-tight mb-1.5">
-                  Last step: save your plan!
-                </p>
-                <p className="text-[14px] text-gray-500 mb-5">
-                  Login to a Next Voters account.
-                </p>
-                <div className="flex items-center justify-center gap-2 text-[13px] font-medium text-gray-500">
-                  <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
-                  Redirecting to Google…
-                </div>
-              </>
-            ) : (
-              <div className="flex flex-col items-center gap-3">
-                <Loader2 className="w-6 h-6 text-gray-400 animate-spin" aria-hidden="true" />
-                <p className="text-[14.5px] font-semibold text-gray-800">
-                  {autoKickoffLabel}
-                </p>
-              </div>
-            )}
+            <p className="text-[17px] font-bold text-gray-950 tracking-tight mb-1.5">
+              Last step: save your plan!
+            </p>
+            <p className="text-[14px] text-gray-500 mb-5">
+              Login to a Next Voters account.
+            </p>
+            <div className="flex items-center justify-center gap-2 text-[13px] font-medium text-gray-500">
+              <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+              Redirecting to Google…
+            </div>
           </div>
         </div>
       )}


### PR DESCRIPTION
Replaces the chat-centric hero with a /local subscription widget. User types a city in the hero, clicks Subscribe, lands on \`/local/onboarding?city=<encoded>\`. The wizard reads the URL param, matches against \`supported_cities\`, and jumps to step 2 (Language) in subscribe or request mode based on the match.

**Two review-flagged ship blockers fixed in the same change:**

1. Wizard's auto-kickoff effect is **removed**. Previously an authed user landing on step 2 of request mode would be silently waitlisted — meaning a logged-in user typing an unsupported city on the hero would skip the \`RequestStep\` consent screen. The effect was also dead weight after localStorage removal (state resets across OAuth).
2. The \`?city=\` hydration effect now strips the param via \`router.replace\` after it runs. Without this, a wizard remount (auth flip, back-nav, gate state change) would reset \`hydratedFromCityParamRef\` and re-fire the effect, clobbering in-progress step 3/4 selections back to step 2.

## Files
- \`app/page.tsx\` — replaces old hero with \`<NewsletterHero />\` wrapper.
- \`components/home/newsletter-hero.tsx\` (new) — hero with city autocomplete + Subscribe CTA → \`/local/onboarding?city=...\`.
- \`components/local/city-autocomplete.tsx\` (new) — shared primitive, \`variant="hero"\` / \`variant="wizard"\`.
- \`components/local/onboarding/onboarding-wizard.tsx\` — adds \`?city=\` hydration effect, strips param after, removes dead auto-kickoff.

## Test plan
- [ ] Land page → type "Vancouver" → Subscribe → \`/local/onboarding?city=Vancouver\` → jumps to step 2 Language, URL cleaned.
- [ ] Same with "Portland" → request mode, step 2 RequestStep (consent screen shown, no silent waitlist).
- [ ] Direct visit to \`/local/onboarding\` with no query → starts at step 1 City.
- [ ] Build clean ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)