### PR TITLE
Carry pending checkout state through OAuth via URL params

### DIFF
--- a/app/local/page.tsx
+++ b/app/local/page.tsx
@@ -2,10 +2,12 @@
 
 import { Suspense, useEffect, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
 import { useSubscription } from '@/hooks/use-subscription';
 import { SubscriptionDashboard } from '@/components/local/subscription-dashboard';
 import { fulfillCheckout } from '@/server-actions/fulfill-checkout';
+import { syncSubscriptionFromStripe } from '@/server-actions/sync-subscription';
 
 function NVLocalInner() {
   const router = useRouter();
@@ -13,14 +15,27 @@ function NVLocalInner() {
   const { user, isLoading: authLoading } = useAuth();
   const { hasSubscription, isLoading: subLoading, refetch } = useSubscription();
   const [fulfilling, setFulfilling] = useState(false);
+  const [kickingOff, setKickingOff] = useState(false);
+  const [kickoffError, setKickoffError] = useState<string | null>(null);
   const fulfilledSessionRef = useRef<string | null>(null);
+  const kickoffFiredRef = useRef(false);
 
   const isPostCheckout = searchParams.get('checkout') === 'success';
   const sessionId = searchParams.get('session_id');
 
-  // Post-Stripe fulfillment. The sessionId-keyed ref guards against duplicate
-  // runs (React 18 StrictMode + any remount) since submitRegionWaitlist inside
-  // fulfillCheckout is not idempotent (emails admin, converts referrals).
+  // URL-carried pending plan handed off from /local/onboarding after OAuth.
+  const pendingPlan = searchParams.get('plan');
+  const pendingCity = searchParams.get('city');
+  const pendingLanguage = searchParams.get('language');
+  const pendingTopicsRaw = searchParams.get('topics');
+  const pendingCityRequest = searchParams.get('cityRequest');
+  const pendingRef = searchParams.get('ref');
+  const hasPendingCheckout = Boolean(
+    pendingPlan && pendingCity && pendingLanguage && pendingTopicsRaw,
+  );
+
+  // Post-Stripe fulfillment. Ref keyed on sessionId guards against StrictMode
+  // double-invocation (submitRegionWaitlist inside is not idempotent).
   useEffect(() => {
     if (!isPostCheckout || !sessionId || !user) return;
     if (fulfilledSessionRef.current === sessionId) return;
@@ -29,8 +44,6 @@ function NVLocalInner() {
     (async () => {
       try {
         const result = await fulfillCheckout(sessionId);
-        // Await refetch so hasSubscription is settled before we flip fulfilling
-        // off — otherwise the redirect effect can race and bounce the user.
         if (result.success) await refetch();
       } finally {
         setFulfilling(false);
@@ -38,20 +51,138 @@ function NVLocalInner() {
     })();
   }, [isPostCheckout, sessionId, user, refetch]);
 
-  // Unauth or authed-without-subscription users get funnelled through onboarding.
+  // Auto-kickoff Stripe checkout using URL-carried plan selection (after OAuth
+  // round-trip from /local/onboarding). Reads the params, POSTs to the checkout
+  // API, redirects the user to Stripe. Falls through to the dashboard if the
+  // user already has an active Stripe sub (via 409 + sync).
   useEffect(() => {
     if (authLoading || subLoading || fulfilling) return;
+    if (!user || hasSubscription) return;
+    if (!hasPendingCheckout) return;
+    if (kickoffFiredRef.current) return;
+    kickoffFiredRef.current = true;
+    setKickingOff(true);
+
+    const topics = pendingTopicsRaw!.split(',').filter(Boolean);
+    const body = {
+      plan: pendingPlan,
+      city: pendingCity,
+      language: pendingLanguage,
+      topics,
+      cityRequest: pendingCityRequest ? { city: pendingCityRequest } : null,
+      referralCode: pendingRef || undefined,
+    };
+
+    (async () => {
+      try {
+        const res = await fetch('/api/stripe/checkout', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+
+        if (res.status === 409) {
+          const syncResult = await syncSubscriptionFromStripe();
+          if (!syncResult.ok) {
+            setKickoffError(
+              syncResult.error ||
+                "You already have an active subscription, but we couldn't sync it. Contact hello@nextvoters.com.",
+            );
+            setKickingOff(false);
+            return;
+          }
+          // Clear URL params before rendering dashboard.
+          router.replace('/local');
+          await refetch();
+          setKickingOff(false);
+          return;
+        }
+
+        const data = await res.json();
+        if (data.url) {
+          window.location.href = data.url;
+          return;
+        }
+        setKickoffError(data.error ?? 'Something went wrong. Please try again.');
+        setKickingOff(false);
+      } catch {
+        setKickoffError("We couldn't reach checkout. Please try again.");
+        setKickingOff(false);
+      }
+    })();
+  }, [
+    authLoading,
+    subLoading,
+    fulfilling,
+    user,
+    hasSubscription,
+    hasPendingCheckout,
+    pendingPlan,
+    pendingCity,
+    pendingLanguage,
+    pendingTopicsRaw,
+    pendingCityRequest,
+    pendingRef,
+    refetch,
+    router,
+  ]);
+
+  // Redirect to onboarding only when there's no pending kickoff in flight.
+  useEffect(() => {
+    if (authLoading || subLoading || fulfilling || kickingOff) return;
+    if (hasPendingCheckout) return;
     if (!user || !hasSubscription) {
       router.replace('/local/onboarding');
     }
-  }, [authLoading, subLoading, fulfilling, user, hasSubscription, router]);
+  }, [
+    authLoading,
+    subLoading,
+    fulfilling,
+    kickingOff,
+    hasPendingCheckout,
+    user,
+    hasSubscription,
+    router,
+  ]);
 
-  if (authLoading || subLoading || fulfilling) {
+  if (authLoading || subLoading || fulfilling || kickingOff) {
+    const label = fulfilling
+      ? 'Setting up your subscription…'
+      : kickingOff
+        ? 'Finishing your setup…'
+        : 'Loading…';
     return (
-      <div className="w-full min-h-[calc(100vh-56px)] bg-page flex items-center justify-center">
-        <p className="text-gray-400 text-[14px]">
-          {fulfilling ? 'Setting up your subscription…' : 'Loading…'}
-        </p>
+      <div className="w-full min-h-[calc(100vh-56px)] bg-page flex items-center justify-center px-5">
+        <div className="flex items-center gap-3 text-gray-500 text-[14px]">
+          <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+          {label}
+        </div>
+      </div>
+    );
+  }
+
+  if (kickoffError) {
+    return (
+      <div className="w-full min-h-[calc(100vh-56px)] bg-page flex items-center justify-center px-5 py-12">
+        <div className="w-full max-w-[400px] bg-white border border-gray-200 rounded-2xl shadow-sm p-8 text-center">
+          <h1 className="text-[20px] font-bold text-gray-950 mb-2 tracking-tight">
+            Checkout didn&apos;t start.
+          </h1>
+          <p
+            className="text-[14px] text-red-700 bg-red-50 border border-red-200 rounded-lg px-3 py-2 mb-6"
+            role="alert"
+            aria-live="polite"
+          >
+            {kickoffError}
+          </p>
+          <button
+            type="button"
+            onClick={() => router.replace('/local/onboarding')}
+            className="inline-flex items-center justify-center min-h-[44px] px-6 text-[14.5px] font-semibold text-white bg-brand rounded-xl hover:bg-brand-hover transition-colors shadow-sm"
+          >
+            Back to plan selection
+          </button>
+        </div>
       </div>
     );
   }

--- a/components/local/onboarding/onboarding-wizard.tsx
+++ b/components/local/onboarding/onboarding-wizard.tsx
@@ -138,14 +138,26 @@ export function OnboardingWizard() {
       setCheckoutError(null);
 
       if (!user) {
+        // Carry the full plan selection through the OAuth round-trip via URL
+        // params (no client storage). /local reads these and auto-fires the
+        // Stripe checkout POST after the user is authed.
         setPendingPlan(plan);
         setPreAuthNotice("Last step: save your plan! Login to a Next Voters account.");
         await new Promise((resolve) => setTimeout(resolve, 1200));
+        const params = new URLSearchParams({
+          plan,
+          city: state.city,
+          language: state.language,
+          topics: state.topics.join(","),
+        });
+        if (state.cityRequest?.city) params.set("cityRequest", state.cityRequest.city);
+        if (referralCode) params.set("ref", referralCode);
+        const next = `/local?${params.toString()}`;
         const supabase = createSupabaseBrowserClient();
         const { error: oauthError } = await supabase.auth.signInWithOAuth({
           provider: "google",
           options: {
-            redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent("/local")}`,
+            redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`,
           },
         });
         if (oauthError) {

--- a/components/local/onboarding/request-step.tsx
+++ b/components/local/onboarding/request-step.tsx
@@ -51,7 +51,7 @@ export function RequestStep({ state, referralCode, onContinue }: Props) {
     const { error: oauthError } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
-        redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent("/local/onboarding")}`,
+        redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(`/local/onboarding?city=${encodeURIComponent(city)}`)}`,
       },
     });
     if (oauthError) {


### PR DESCRIPTION
Fixes the unauth → onboarding → Google sign-in → Stripe flow. Since the localStorage removal, React state didn't survive the OAuth round-trip, so the user landed at /local with no pending plan → got bounced to /local/onboarding → wizard restarted at step 1. Replaces that handoff with URL params.

### Subscribe path
- Wizard plan CTA (unauth) encodes \`plan + city + language + topics\` (+ optional \`cityRequest\`, \`referralCode\`) into the OAuth redirect's \`next\` URL → \`/local?plan=…&city=…&language=…&topics=…\`.
- \`/local\` detects the params, POSTs \`/api/stripe/checkout\` once auth resolves, then redirects to Stripe.
- On 409, calls \`syncSubscriptionFromStripe\` then \`refetch()\` — dashboard renders.
- Ref-keyed guard so the kickoff fires once per page load. Fallback "redirect to onboarding" is suppressed while pending kickoff is in flight.

### Request path
- RequestStep Google button encodes city into the redirect's \`next\` URL → \`/local/onboarding?city=…\`.
- The wizard's existing \`?city=\` hydration re-enters request mode step 2 after OAuth; the authed user sees the "Notify me about X" consent button and submits the waitlist.

No client storage added. Tomorrow's Supabase-backed state will supersede this URL-handoff mechanism for fuller state (step progress, back-nav).

## Test plan
- [ ] Unauth user completes onboarding → clicks Start free → Google → back at \`/local?plan=…\` → "Finishing your setup…" → Stripe → success → dashboard.
- [ ] Same flow but with a customer that already has an active Stripe sub → 409 → sync → dashboard renders (no ping-pong).
- [ ] Unauth user picks unsupported city → RequestStep → Google → back at \`/local/onboarding?city=Portland\` → request mode step 2 → "Notify me about Portland" → step 3.
- [ ] \`pnpm build\` clean ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)