### PR TITLE
Redirect /local to onboarding when user is null even with pending params

### DIFF
--- a/app/local/page.tsx
+++ b/app/local/page.tsx
@@ -127,13 +127,20 @@ function NVLocalInner() {
     router,
   ]);
 
-  // Redirect to onboarding only when there's no pending kickoff in flight.
+  // Redirect to onboarding for anyone without a subscription. Exception:
+  // stay put while a pending kickoff is about to fire (authed user just
+  // returned from OAuth) — but if the user is null (genuinely unauth, or
+  // the rare case of stale URL params with no session), send them through
+  // onboarding regardless, otherwise we'd render nothing.
   useEffect(() => {
     if (authLoading || subLoading || fulfilling || kickingOff) return;
-    if (hasPendingCheckout) return;
-    if (!user || !hasSubscription) {
+    if (!user) {
       router.replace('/local/onboarding');
+      return;
     }
+    if (hasSubscription) return;
+    if (hasPendingCheckout) return;
+    router.replace('/local/onboarding');
   }, [
     authLoading,
     subLoading,


### PR DESCRIPTION
Fixes an edge case in the subscribe-handoff flow introduced in PR #90.

**Bug:** the redirect effect on \`/local\` was:
\`\`\`ts
if (authLoading || subLoading || fulfilling || kickingOff) return;
if (hasPendingCheckout) return;
if (!user || !hasSubscription) router.replace('/local/onboarding');
\`\`\`

If \`user === null\` AND \`hasPendingCheckout === true\` (e.g., stale bookmarked \`/local?plan=...\` URL, or the rare Supabase cookie-propagation delay right after OAuth), the effect bailed on \`hasPendingCheckout\`. The kickoff effect also bailed (\`!user\`), so we rendered nothing — blank page.

**Fix:** redirect unconditionally when \`user === null\`, regardless of pending params. In the rare cookie-delay case, the user will just re-click the plan CTA on the wizard.

## Test plan
- [ ] Manually navigate to \`/local?plan=free&city=X&language=Y&topics=Z\` while signed out → redirect to \`/local/onboarding\` (was: blank page).
- [ ] Normal subscribe flow still works (unauth wizard → OAuth → /local with params → kickoff → Stripe).
- [ ] Build clean ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)