### PR TITLE
Preserve wizard state across /local ↔ /local/onboarding bounces

### DIFF
--- a/app/local/page.tsx
+++ b/app/local/page.tsx
@@ -1,13 +1,31 @@
 'use client';
 
-import { Suspense, useEffect, useRef, useState } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useRouter,
+  useSearchParams,
+  type ReadonlyURLSearchParams,
+} from 'next/navigation';
 import { Loader2 } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
 import { useSubscription } from '@/hooks/use-subscription';
 import { SubscriptionDashboard } from '@/components/local/subscription-dashboard';
 import { fulfillCheckout } from '@/server-actions/fulfill-checkout';
 import { syncSubscriptionFromStripe } from '@/server-actions/sync-subscription';
+
+// Build a /local/onboarding URL that preserves any in-flight wizard state
+// params so the wizard hydrates back to the user's last step instead of
+// starting over at step 1.
+function onboardingReturnUrl(searchParams: ReadonlyURLSearchParams): string {
+  const KEEP = ['city', 'language', 'topics', 'cityRequest', 'ref'] as const;
+  const out = new URLSearchParams();
+  for (const key of KEEP) {
+    const value = searchParams.get(key);
+    if (value) out.set(key, value);
+  }
+  const qs = out.toString();
+  return qs ? `/local/onboarding?${qs}` : '/local/onboarding';
+}
 
 function NVLocalInner() {
   const router = useRouter();
@@ -32,6 +50,10 @@ function NVLocalInner() {
   const pendingRef = searchParams.get('ref');
   const hasPendingCheckout = Boolean(
     pendingPlan && pendingCity && pendingLanguage && pendingTopicsRaw,
+  );
+  const onboardingFallback = useMemo(
+    () => onboardingReturnUrl(searchParams),
+    [searchParams],
   );
 
   // Post-Stripe fulfillment. Ref keyed on sessionId guards against StrictMode
@@ -131,16 +153,17 @@ function NVLocalInner() {
   // stay put while a pending kickoff is about to fire (authed user just
   // returned from OAuth) — but if the user is null (genuinely unauth, or
   // the rare case of stale URL params with no session), send them through
-  // onboarding regardless, otherwise we'd render nothing.
+  // onboarding regardless. Preserve wizard state params on the redirect
+  // so the wizard hydrates back to the user's last step.
   useEffect(() => {
     if (authLoading || subLoading || fulfilling || kickingOff) return;
     if (!user) {
-      router.replace('/local/onboarding');
+      router.replace(onboardingFallback);
       return;
     }
     if (hasSubscription) return;
     if (hasPendingCheckout) return;
-    router.replace('/local/onboarding');
+    router.replace(onboardingFallback);
   }, [
     authLoading,
     subLoading,
@@ -150,6 +173,7 @@ function NVLocalInner() {
     user,
     hasSubscription,
     router,
+    onboardingFallback,
   ]);
 
   if (authLoading || subLoading || fulfilling || kickingOff) {
@@ -184,7 +208,7 @@ function NVLocalInner() {
           </p>
           <button
             type="button"
-            onClick={() => router.replace('/local/onboarding')}
+            onClick={() => router.replace(onboardingFallback)}
             className="inline-flex items-center justify-center min-h-[44px] px-6 text-[14.5px] font-semibold text-white bg-brand rounded-xl hover:bg-brand-hover transition-colors shadow-sm"
           >
             Back to plan selection

--- a/components/local/onboarding/onboarding-wizard.tsx
+++ b/components/local/onboarding/onboarding-wizard.tsx
@@ -82,10 +82,13 @@ export function OnboardingWizard() {
     }
   }, [urlRef, referralCode, setReferralCode]);
 
-  // Pre-fill city from `?city=` (e.g., from the landing-page hero). Runs once
-  // after cities load so the supported-match check is valid. The URL param is
-  // stripped after hydration so a remount (auth flip, back-nav) can't re-fire
-  // this effect and clobber user progress past step 2.
+  // Pre-fill city from `?city=` (e.g., from the landing-page hero or the
+  // /local → onboarding "Back to plan selection" path). Also accepts
+  // `?language=` and `?topics=` (comma-sep) so a user returning from a failed
+  // kickoff or from a Supabase cookie-delay redirect lands back on their
+  // furthest-completed step instead of step 1. Runs once after cities load so
+  // the supported-match check is valid. URL is stripped after hydration so a
+  // remount (auth flip, back-nav) can't re-fire this effect.
   useEffect(() => {
     if (citiesLoading || hydratedFromCityParamRef.current) return;
     if (!urlCity) return;
@@ -93,15 +96,34 @@ export function OnboardingWizard() {
     if (!trimmed) return;
     hydratedFromCityParamRef.current = true;
 
+    const urlLanguage = searchParams.get("language")?.trim() ?? "";
+    const urlTopicsRaw = searchParams.get("topics");
+    const urlTopics = urlTopicsRaw
+      ? urlTopicsRaw.split(",").map((t) => t.trim()).filter(Boolean)
+      : [];
+
     const match = supportedCities.find(
       (c) => c.toLowerCase() === trimmed.toLowerCase(),
     );
     if (match) {
-      updateState({ city: match, cityRequest: null });
+      updateState({
+        city: match,
+        cityRequest: null,
+        language: urlLanguage,
+        topics: urlTopics,
+      });
       setMode("subscribe");
-      setStep(2);
+      // Jump to the furthest step the hydrated state unlocks.
+      if (urlLanguage && urlTopics.length > 0) setStep(4);
+      else if (urlLanguage) setStep(3);
+      else setStep(2);
     } else {
-      updateState({ city: "", cityRequest: { city: trimmed } });
+      updateState({
+        city: "",
+        cityRequest: { city: trimmed },
+        language: urlLanguage,
+        topics: urlTopics,
+      });
       setMode("request");
       setStep(2);
     }
@@ -111,6 +133,7 @@ export function OnboardingWizard() {
     citiesLoading,
     supportedCities,
     urlCity,
+    searchParams,
     updateState,
     setMode,
     setStep,


### PR DESCRIPTION
Fixes the two residual gaps from PR #90 / #91.

### Gap 1: "Back to plan selection" lost state
Kickoff-error card redirected to \`/local/onboarding\` with no params. Wizard (React state only) restarted at step 1.

### Gap 2: Cookie-delay redirect lost state
PR #91 redirects user=null on \`/local\` to \`/local/onboarding\` without params — wizard restarted at step 1.

### Fix (URL-only, no new persistence)

\`/local\`:
- Memoized \`onboardingFallback\` URL forwards \`city\`, \`language\`, \`topics\`, \`cityRequest\`, \`ref\`.
- Used in: redirect-on-user=null, redirect-on-no-subscription, "Back to plan selection" button.

Wizard hydration effect:
- Now reads \`?language=\` and \`?topics=\` in addition to \`?city=\`.
- Jumps to the furthest completed step: step 4 if city+language+topics, step 3 if city+language, step 2 otherwise.
- Request-mode hydration unchanged (always step 2 RequestStep).

## Test plan
- [ ] Force a kickoff error on \`/local\` (e.g. return 500 from /api/stripe/checkout). Click "Back to plan selection" → wizard lands on step 4 (Plan) with previous selections intact.
- [ ] Manually hit \`/local?plan=free&city=X&language=Y&topics=Z\` while signed-out → redirects to \`/local/onboarding?city=X&language=Y&topics=Z\` → wizard hydrates to step 4.
- [ ] Hero → \`/local/onboarding?city=Vancouver\` → still works, lands on step 2 (Language) as before.
- [ ] Request flow via \`/local/onboarding?city=Portland\` → lands on step 2 RequestStep unchanged.
- [ ] \`pnpm build\` clean ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)