### PR TITLE
Carry OAuth state via cookie instead of nested redirectTo URL

### DIFF
--- a/app/local/page.tsx
+++ b/app/local/page.tsx
@@ -1,31 +1,18 @@
 'use client';
 
-import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
-import {
-  useRouter,
-  useSearchParams,
-  type ReadonlyURLSearchParams,
-} from 'next/navigation';
+import { Suspense, useEffect, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { Loader2 } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
 import { useSubscription } from '@/hooks/use-subscription';
 import { SubscriptionDashboard } from '@/components/local/subscription-dashboard';
+import {
+  clearPendingAction,
+  readPendingAction,
+  type PendingAction,
+} from '@/lib/pending-action';
 import { fulfillCheckout } from '@/server-actions/fulfill-checkout';
 import { syncSubscriptionFromStripe } from '@/server-actions/sync-subscription';
-
-// Build a /local/onboarding URL that preserves any in-flight wizard state
-// params so the wizard hydrates back to the user's last step instead of
-// starting over at step 1.
-function onboardingReturnUrl(searchParams: ReadonlyURLSearchParams): string {
-  const KEEP = ['city', 'language', 'topics', 'cityRequest', 'ref'] as const;
-  const out = new URLSearchParams();
-  for (const key of KEEP) {
-    const value = searchParams.get(key);
-    if (value) out.set(key, value);
-  }
-  const qs = out.toString();
-  return qs ? `/local/onboarding?${qs}` : '/local/onboarding';
-}
 
 function NVLocalInner() {
   const router = useRouter();
@@ -35,26 +22,21 @@ function NVLocalInner() {
   const [fulfilling, setFulfilling] = useState(false);
   const [kickingOff, setKickingOff] = useState(false);
   const [kickoffError, setKickoffError] = useState<string | null>(null);
+  const [pending, setPending] = useState<PendingAction | null>(null);
+  const [pendingChecked, setPendingChecked] = useState(false);
   const fulfilledSessionRef = useRef<string | null>(null);
   const kickoffFiredRef = useRef(false);
 
   const isPostCheckout = searchParams.get('checkout') === 'success';
   const sessionId = searchParams.get('session_id');
 
-  // URL-carried pending plan handed off from /local/onboarding after OAuth.
-  const pendingPlan = searchParams.get('plan');
-  const pendingCity = searchParams.get('city');
-  const pendingLanguage = searchParams.get('language');
-  const pendingTopicsRaw = searchParams.get('topics');
-  const pendingCityRequest = searchParams.get('cityRequest');
-  const pendingRef = searchParams.get('ref');
-  const hasPendingCheckout = Boolean(
-    pendingPlan && pendingCity && pendingLanguage && pendingTopicsRaw,
-  );
-  const onboardingFallback = useMemo(
-    () => onboardingReturnUrl(searchParams),
-    [searchParams],
-  );
+  // Read the pending-action cookie once on mount.
+  useEffect(() => {
+    setPending(readPendingAction());
+    setPendingChecked(true);
+  }, []);
+
+  const hasSubscribeIntent = pending?.type === 'subscribe';
 
   // Post-Stripe fulfillment. Ref keyed on sessionId guards against StrictMode
   // double-invocation (submitRegionWaitlist inside is not idempotent).
@@ -73,37 +55,35 @@ function NVLocalInner() {
     })();
   }, [isPostCheckout, sessionId, user, refetch]);
 
-  // Auto-kickoff Stripe checkout using URL-carried plan selection (after OAuth
-  // round-trip from /local/onboarding). Reads the params, POSTs to the checkout
-  // API, redirects the user to Stripe. Falls through to the dashboard if the
-  // user already has an active Stripe sub (via 409 + sync).
+  // Subscribe kickoff: cookie carries the pending selection after OAuth.
   useEffect(() => {
+    if (!pendingChecked) return;
     if (authLoading || subLoading || fulfilling) return;
     if (!user || hasSubscription) return;
-    if (!hasPendingCheckout) return;
+    if (!hasSubscribeIntent) return;
     if (kickoffFiredRef.current) return;
     kickoffFiredRef.current = true;
     setKickingOff(true);
 
-    const topics = pendingTopicsRaw!.split(',').filter(Boolean);
-    const body = {
-      plan: pendingPlan,
-      city: pendingCity,
-      language: pendingLanguage,
-      topics,
-      cityRequest: pendingCityRequest ? { city: pendingCityRequest } : null,
-      referralCode: pendingRef || undefined,
-    };
+    const sub = pending as Extract<PendingAction, { type: 'subscribe' }>;
 
     (async () => {
       try {
         const res = await fetch('/api/stripe/checkout', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify(body),
+          body: JSON.stringify({
+            plan: sub.plan,
+            city: sub.city,
+            language: sub.language,
+            topics: sub.topics,
+            cityRequest: sub.cityRequest,
+            referralCode: sub.referralCode || undefined,
+          }),
         });
 
         if (res.status === 409) {
+          clearPendingAction();
           const syncResult = await syncSubscriptionFromStripe();
           if (!syncResult.ok) {
             setKickoffError(
@@ -113,8 +93,6 @@ function NVLocalInner() {
             setKickingOff(false);
             return;
           }
-          // Clear URL params before rendering dashboard.
-          router.replace('/local');
           await refetch();
           setKickingOff(false);
           return;
@@ -122,61 +100,57 @@ function NVLocalInner() {
 
         const data = await res.json();
         if (data.url) {
+          clearPendingAction();
           window.location.href = data.url;
           return;
         }
+        clearPendingAction();
         setKickoffError(data.error ?? 'Something went wrong. Please try again.');
         setKickingOff(false);
       } catch {
+        clearPendingAction();
         setKickoffError("We couldn't reach checkout. Please try again.");
         setKickingOff(false);
       }
     })();
   }, [
+    pendingChecked,
     authLoading,
     subLoading,
     fulfilling,
     user,
     hasSubscription,
-    hasPendingCheckout,
-    pendingPlan,
-    pendingCity,
-    pendingLanguage,
-    pendingTopicsRaw,
-    pendingCityRequest,
-    pendingRef,
+    hasSubscribeIntent,
+    pending,
     refetch,
-    router,
   ]);
 
-  // Redirect to onboarding for anyone without a subscription. Exception:
-  // stay put while a pending kickoff is about to fire (authed user just
-  // returned from OAuth) — but if the user is null (genuinely unauth, or
-  // the rare case of stale URL params with no session), send them through
-  // onboarding regardless. Preserve wizard state params on the redirect
-  // so the wizard hydrates back to the user's last step.
+  // Redirect for anyone without a subscription. Exception: stay put while a
+  // subscribe kickoff is about to fire or in flight. When user=null, always
+  // bounce through onboarding (cookie survives to the next /local visit).
   useEffect(() => {
+    if (!pendingChecked) return;
     if (authLoading || subLoading || fulfilling || kickingOff) return;
     if (!user) {
-      router.replace(onboardingFallback);
+      router.replace('/local/onboarding');
       return;
     }
     if (hasSubscription) return;
-    if (hasPendingCheckout) return;
-    router.replace(onboardingFallback);
+    if (hasSubscribeIntent) return;
+    router.replace('/local/onboarding');
   }, [
+    pendingChecked,
     authLoading,
     subLoading,
     fulfilling,
     kickingOff,
-    hasPendingCheckout,
     user,
     hasSubscription,
+    hasSubscribeIntent,
     router,
-    onboardingFallback,
   ]);
 
-  if (authLoading || subLoading || fulfilling || kickingOff) {
+  if (authLoading || subLoading || fulfilling || kickingOff || !pendingChecked) {
     const label = fulfilling
       ? 'Setting up your subscription…'
       : kickingOff
@@ -208,7 +182,7 @@ function NVLocalInner() {
           </p>
           <button
             type="button"
-            onClick={() => router.replace(onboardingFallback)}
+            onClick={() => router.replace('/local/onboarding')}
             className="inline-flex items-center justify-center min-h-[44px] px-6 text-[14.5px] font-semibold text-white bg-brand rounded-xl hover:bg-brand-hover transition-colors shadow-sm"
           >
             Back to plan selection

--- a/components/local/onboarding/onboarding-wizard.tsx
+++ b/components/local/onboarding/onboarding-wizard.tsx
@@ -5,7 +5,13 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { ArrowLeft, Loader2 } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+import {
+  clearPendingAction,
+  readPendingAction,
+  writePendingAction,
+} from "@/lib/pending-action";
 import { getSupportedCities } from "@/server-actions/get-supported-cities";
+import { submitRegionWaitlist } from "@/server-actions/request-region";
 import { syncSubscriptionFromStripe } from "@/server-actions/sync-subscription";
 import { CityStep } from "./city-step";
 import { LanguageStep } from "./language-step";
@@ -58,9 +64,11 @@ export function OnboardingWizard() {
   );
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [preAuthNotice, setPreAuthNotice] = useState<string | null>(null);
+  const [autoKickoffLabel, setAutoKickoffLabel] = useState<string | null>(null);
   const headingRef = useRef<HTMLHeadingElement>(null);
   const isFirstStepChangeRef = useRef(true);
   const hydratedFromCityParamRef = useRef(false);
+  const requestCookieHandledRef = useRef(false);
 
   useEffect(() => {
     getSupportedCities()
@@ -140,6 +148,50 @@ export function OnboardingWizard() {
     router,
   ]);
 
+  // Request-flow OAuth return: cookie carries the requested city. We land on
+  // /local/onboarding post-auth; read the cookie, auto-submit the waitlist,
+  // and advance to the alternatives step. One-shot via ref.
+  useEffect(() => {
+    if (requestCookieHandledRef.current) return;
+    if (!user?.email) return;
+    const pending = readPendingAction();
+    if (!pending || pending.type !== "request") return;
+    if (!pending.city) {
+      clearPendingAction();
+      return;
+    }
+    requestCookieHandledRef.current = true;
+
+    updateState({
+      city: "",
+      cityRequest: { city: pending.city },
+    });
+    setMode("request");
+    setStep(2);
+    setAutoKickoffLabel(`Adding ${pending.city} to your waitlist…`);
+
+    (async () => {
+      try {
+        const result = await submitRegionWaitlist({
+          city: pending.city,
+          voterEmail: user.email!,
+          referralCode: pending.referralCode || undefined,
+        });
+        clearPendingAction();
+        if (result.ok === false) {
+          setCheckoutError(result.error);
+        } else {
+          setStep(3);
+        }
+      } catch {
+        clearPendingAction();
+        setCheckoutError("We couldn't save your request. Please try again.");
+      } finally {
+        setAutoKickoffLabel(null);
+      }
+    })();
+  }, [user, updateState, setMode, setStep]);
+
   const totalSteps = mode === "request" ? 3 : 4;
   const stepLabel =
     mode === "request"
@@ -161,29 +213,33 @@ export function OnboardingWizard() {
       setCheckoutError(null);
 
       if (!user) {
-        // Carry the full plan selection through the OAuth round-trip via URL
-        // params (no client storage). /local reads these and auto-fires the
-        // Stripe checkout POST after the user is authed.
-        setPendingPlan(plan);
-        setPreAuthNotice("Last step: save your plan! Login to a Next Voters account.");
-        await new Promise((resolve) => setTimeout(resolve, 1200));
-        const params = new URLSearchParams({
+        // Carry the full plan selection through the OAuth round-trip via a
+        // SameSite=Lax cookie. Embedding state in `redirectTo` (e.g.
+        // `?next=%2Flocal%3Fplan%3D...`) is fragile: Supabase strict-matches
+        // redirect URLs and falls back to the Site URL on mismatch, stranding
+        // the user on the home page. The redirectTo stays clean; /local reads
+        // the cookie and fires the Stripe POST after auth settles.
+        writePendingAction({
+          type: "subscribe",
           plan,
           city: state.city,
           language: state.language,
-          topics: state.topics.join(","),
+          topics: state.topics,
+          cityRequest: state.cityRequest,
+          referralCode: referralCode || null,
         });
-        if (state.cityRequest?.city) params.set("cityRequest", state.cityRequest.city);
-        if (referralCode) params.set("ref", referralCode);
-        const next = `/local?${params.toString()}`;
+        setPendingPlan(plan);
+        setPreAuthNotice("Last step: save your plan! Login to a Next Voters account.");
+        await new Promise((resolve) => setTimeout(resolve, 1200));
         const supabase = createSupabaseBrowserClient();
         const { error: oauthError } = await supabase.auth.signInWithOAuth({
           provider: "google",
           options: {
-            redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(next)}`,
+            redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent("/local")}`,
           },
         });
         if (oauthError) {
+          clearPendingAction();
           setPreAuthNotice(null);
           setCheckoutError(oauthError.message);
           scrollToBottom();
@@ -371,23 +427,34 @@ export function OnboardingWizard() {
         )}
       </div>
 
-      {preAuthNotice && (
+      {(preAuthNotice || autoKickoffLabel) && (
         <div
           className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 px-5 animate-in fade-in duration-150"
           role="status"
           aria-live="polite"
         >
           <div className="w-full max-w-[380px] bg-white rounded-2xl shadow-xl p-6 text-center">
-            <p className="text-[17px] font-bold text-gray-950 tracking-tight mb-1.5">
-              Last step: save your plan!
-            </p>
-            <p className="text-[14px] text-gray-500 mb-5">
-              Login to a Next Voters account.
-            </p>
-            <div className="flex items-center justify-center gap-2 text-[13px] font-medium text-gray-500">
-              <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
-              Redirecting to Google…
-            </div>
+            {preAuthNotice ? (
+              <>
+                <p className="text-[17px] font-bold text-gray-950 tracking-tight mb-1.5">
+                  Last step: save your plan!
+                </p>
+                <p className="text-[14px] text-gray-500 mb-5">
+                  Login to a Next Voters account.
+                </p>
+                <div className="flex items-center justify-center gap-2 text-[13px] font-medium text-gray-500">
+                  <Loader2 className="w-4 h-4 animate-spin" aria-hidden="true" />
+                  Redirecting to Google…
+                </div>
+              </>
+            ) : (
+              <div className="flex flex-col items-center gap-3">
+                <Loader2 className="w-6 h-6 text-gray-400 animate-spin" aria-hidden="true" />
+                <p className="text-[14.5px] font-semibold text-gray-800">
+                  {autoKickoffLabel}
+                </p>
+              </div>
+            )}
           </div>
         </div>
       )}

--- a/components/local/onboarding/request-step.tsx
+++ b/components/local/onboarding/request-step.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useAuth } from "@/hooks/use-auth";
 import { createSupabaseBrowserClient } from "@/lib/supabase/client";
+import { clearPendingAction, writePendingAction } from "@/lib/pending-action";
 import { submitRegionWaitlist } from "@/server-actions/request-region";
 import { OnboardingState } from "./types";
 
@@ -47,14 +48,21 @@ export function RequestStep({ state, referralCode, onContinue }: Props) {
   const handleGoogleSignIn = async () => {
     setError(null);
     setSubmitting(true);
+    // Carry requested city via cookie (see lib/pending-action.ts for why).
+    writePendingAction({
+      type: "request",
+      city,
+      referralCode: referralCode || null,
+    });
     const supabase = createSupabaseBrowserClient();
     const { error: oauthError } = await supabase.auth.signInWithOAuth({
       provider: "google",
       options: {
-        redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(`/local/onboarding?city=${encodeURIComponent(city)}`)}`,
+        redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent("/local/onboarding")}`,
       },
     });
     if (oauthError) {
+      clearPendingAction();
       setError(oauthError.message);
       setSubmitting(false);
     }

--- a/lib/pending-action.ts
+++ b/lib/pending-action.ts
@@ -1,0 +1,68 @@
+// Client-side cookie that carries onboarding state across the Google OAuth
+// round-trip without embedding it in the OAuth redirect URL. Embedding state
+// in `redirectTo` runs into Supabase's redirect-URL whitelist matching: an
+// encoded query-string-inside-a-query-string can fail strict-matching and
+// Supabase falls back to the project's Site URL, stranding the user at home.
+//
+// A cookie with SameSite=Lax survives top-level cross-site GET redirects,
+// so it's preserved through the Google → Supabase → /auth/callback → /local
+// redirect chain. Cleared on success or abandonment.
+
+export type PendingAction =
+  | {
+      type: "subscribe";
+      plan: "free" | "pro";
+      city: string;
+      language: string;
+      topics: string[];
+      cityRequest: { city: string } | null;
+      referralCode: string | null;
+    }
+  | {
+      type: "request";
+      city: string;
+      referralCode: string | null;
+    };
+
+const COOKIE_NAME = "nv_pending_action";
+const MAX_AGE_SECONDS = 15 * 60;
+
+function encodeUtf8ToBase64(input: string): string {
+  // UTF-8 safe base64 encode. btoa() alone mangles non-ASCII characters.
+  return btoa(unescape(encodeURIComponent(input)));
+}
+
+function decodeBase64ToUtf8(input: string): string {
+  return decodeURIComponent(escape(atob(input)));
+}
+
+export function writePendingAction(action: PendingAction): void {
+  if (typeof document === "undefined") return;
+  const encoded = encodeUtf8ToBase64(JSON.stringify(action));
+  const secure =
+    typeof location !== "undefined" && location.protocol === "https:"
+      ? "; Secure"
+      : "";
+  document.cookie = `${COOKIE_NAME}=${encoded}; Path=/; Max-Age=${MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
+}
+
+export function readPendingAction(): PendingAction | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie.match(
+    new RegExp(`(?:^|;\\s*)${COOKIE_NAME}=([^;]+)`),
+  );
+  if (!match) return null;
+  try {
+    const json = decodeBase64ToUtf8(match[1]);
+    const parsed = JSON.parse(json) as PendingAction;
+    if (parsed.type !== "subscribe" && parsed.type !== "request") return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingAction(): void {
+  if (typeof document === "undefined") return;
+  document.cookie = `${COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax`;
+}


### PR DESCRIPTION
Fixes the broken unauth → onboarding → Google sign-in flow.

## Root cause
Embedding onboarding state as nested query params in the OAuth \`redirectTo\` (e.g. \`?next=%2Flocal%3Fplan%3Dfree%26city%3D...\`) was being rejected by Supabase's redirect-URL whitelist matching. Supabase fell back to the project's Site URL, so the browser landed on the home page instead of \`/local\`, and the Stripe kickoff never fired.

## Fix
State now lives in a same-origin cookie (\`nv_pending_action\`, SameSite=Lax, 15-min max-age) that survives the OAuth top-level redirect chain. \`redirectTo\` URLs are now clean:
- Subscribe: \`/auth/callback?next=/local\`
- Request: \`/auth/callback?next=/local/onboarding\`

Both are stable strings that match Supabase's whitelist cleanly.

### Files
- \`lib/pending-action.ts\` (new) — client-side cookie helper with a discriminated-union payload (\`{ type: "subscribe", ... }\` | \`{ type: "request", ... }\`).
- \`components/local/onboarding/onboarding-wizard.tsx\` — writes subscribe payload before OAuth; new on-mount effect reads the cookie, hydrates request state, auto-submits waitlist, advances to step 3.
- \`components/local/onboarding/request-step.tsx\` — writes request payload before OAuth.
- \`app/local/page.tsx\` — reads cookie on mount (gated via \`pendingChecked\`); fires Stripe POST when subscribe intent present; handles 409 with sync; clears cookie on success/error.

## Test plan
- [ ] Unauth → wizard → Start Free → Google → lands at \`/local\` → "Finishing your setup…" → Stripe checkout URL.
- [ ] Stripe success → /local?checkout=success → dashboard.
- [ ] Unauth → wizard → unsupported city → RequestStep → Google → lands at \`/local/onboarding\` → "Adding X to your waitlist…" → step 3 alternatives.
- [ ] Already-subscribed customer with stale DB → 409 → sync → dashboard (no ping-pong).
- [ ] \`pnpm build\` clean ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)