### PR TITLE
Harden pending-action cookie (validation, timestamp, modern encoding)

### DIFF
--- a/components/local/onboarding/onboarding-wizard.tsx
+++ b/components/local/onboarding/onboarding-wizard.tsx
@@ -219,6 +219,11 @@ export function OnboardingWizard() {
         // redirect URLs and falls back to the Site URL on mismatch, stranding
         // the user on the home page. The redirectTo stays clean; /local reads
         // the cookie and fires the Stripe POST after auth settles.
+        setPendingPlan(plan);
+        setPreAuthNotice("Last step: save your plan! Login to a Next Voters account.");
+        await new Promise((resolve) => setTimeout(resolve, 1200));
+        // Write the cookie just before OAuth so a user who bails during the
+        // 1.2s notice window doesn't leave a stale cookie behind.
         writePendingAction({
           type: "subscribe",
           plan,
@@ -228,9 +233,6 @@ export function OnboardingWizard() {
           cityRequest: state.cityRequest,
           referralCode: referralCode || null,
         });
-        setPendingPlan(plan);
-        setPreAuthNotice("Last step: save your plan! Login to a Next Voters account.");
-        await new Promise((resolve) => setTimeout(resolve, 1200));
         const supabase = createSupabaseBrowserClient();
         const { error: oauthError } = await supabase.auth.signInWithOAuth({
           provider: "google",

--- a/lib/pending-action.ts
+++ b/lib/pending-action.ts
@@ -6,7 +6,9 @@
 //
 // A cookie with SameSite=Lax survives top-level cross-site GET redirects,
 // so it's preserved through the Google → Supabase → /auth/callback → /local
-// redirect chain. Cleared on success or abandonment.
+// redirect chain. Cleared on success or explicit failure. Stale cookies
+// older than MAX_AGE_SECONDS are ignored on read even if the browser hasn't
+// evicted them yet.
 
 export type PendingAction =
   | {
@@ -24,21 +26,70 @@ export type PendingAction =
       referralCode: string | null;
     };
 
+interface StoredPendingAction {
+  ts: number;
+  action: PendingAction;
+}
+
 const COOKIE_NAME = "nv_pending_action";
 const MAX_AGE_SECONDS = 15 * 60;
+const MAX_AGE_MS = MAX_AGE_SECONDS * 1000;
 
 function encodeUtf8ToBase64(input: string): string {
-  // UTF-8 safe base64 encode. btoa() alone mangles non-ASCII characters.
-  return btoa(unescape(encodeURIComponent(input)));
+  const bytes = new TextEncoder().encode(input);
+  let binary = "";
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
 }
 
 function decodeBase64ToUtf8(input: string): string {
-  return decodeURIComponent(escape(atob(input)));
+  const binary = atob(input);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((v) => typeof v === "string");
+}
+
+function isCityRequest(value: unknown): value is { city: string } | null {
+  if (value === null) return true;
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return typeof v.city === "string";
+}
+
+function isPendingAction(value: unknown): value is PendingAction {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  if (v.type === "subscribe") {
+    return (
+      (v.plan === "free" || v.plan === "pro") &&
+      typeof v.city === "string" &&
+      typeof v.language === "string" &&
+      isStringArray(v.topics) &&
+      isCityRequest(v.cityRequest) &&
+      (v.referralCode === null || typeof v.referralCode === "string")
+    );
+  }
+  if (v.type === "request") {
+    return (
+      typeof v.city === "string" &&
+      (v.referralCode === null || typeof v.referralCode === "string")
+    );
+  }
+  return false;
 }
 
 export function writePendingAction(action: PendingAction): void {
   if (typeof document === "undefined") return;
-  const encoded = encodeUtf8ToBase64(JSON.stringify(action));
+  const stored: StoredPendingAction = { ts: Date.now(), action };
+  const encoded = encodeUtf8ToBase64(JSON.stringify(stored));
   const secure =
     typeof location !== "undefined" && location.protocol === "https:"
       ? "; Secure"
@@ -52,14 +103,18 @@ export function readPendingAction(): PendingAction | null {
     new RegExp(`(?:^|;\\s*)${COOKIE_NAME}=([^;]+)`),
   );
   if (!match) return null;
+  let parsed: unknown;
   try {
-    const json = decodeBase64ToUtf8(match[1]);
-    const parsed = JSON.parse(json) as PendingAction;
-    if (parsed.type !== "subscribe" && parsed.type !== "request") return null;
-    return parsed;
+    parsed = JSON.parse(decodeBase64ToUtf8(match[1]));
   } catch {
     return null;
   }
+  if (!parsed || typeof parsed !== "object") return null;
+  const stored = parsed as Partial<StoredPendingAction>;
+  if (typeof stored.ts !== "number") return null;
+  if (Date.now() - stored.ts > MAX_AGE_MS) return null;
+  if (!isPendingAction(stored.action)) return null;
+  return stored.action;
 }
 
 export function clearPendingAction(): void {


### PR DESCRIPTION
Code review follow-ups on PR #93.

### Critical fix
- **Runtime shape validation** in \`readPendingAction\`. The previous version only checked the \`type\` discriminator and then cast to \`PendingAction\`. A malformed/tampered cookie with \`type: "subscribe"\` but garbage elsewhere (e.g. \`plan: "enterprise"\`, non-string \`city\`) would flow straight to \`/api/stripe/checkout\`. Server validates inputs, so there's no auth-boundary bypass, but the client now rejects invalid payloads at the door.

### Moderate fixes
- **Timestamp envelope**: payload wrapped as \`{ ts, action }\`; read rejects when \`ts\` is >15 min old. Belt-and-suspenders to the browser's \`Max-Age\`.
- **Modern UTF-8 encoding**: \`escape\`/\`unescape\` replaced with \`TextEncoder\`/\`TextDecoder\` + \`btoa\`/\`atob\` via \`Uint8Array\` round-trip.
- **Narrowed stuck-cookie window**: wizard's \`writePendingAction\` now runs *after* the 1.2s pre-OAuth notice. If the user bails during the notice, no cookie is left behind.

### Deferred (from review, not ship-blocking)
- Extracting the duplicated Stripe kickoff + 409-sync logic to \`lib/stripe-kickoff.ts\` (between wizard authed path and /local). Nice cleanup, not a correctness fix.
- Switching to a server-action-set HttpOnly cookie. Current state is user-controllable, but the payload isn't sensitive and the server validates anyway.

## Test plan
- [ ] Manually corrupt the cookie (DevTools → Application → Cookies → edit value) → refresh /local → should bounce to onboarding (not 500 or crash).
- [ ] Set the cookie with a very old \`ts\` (simulate stale) → refresh → treated as absent.
- [ ] Happy path: unauth → wizard → OAuth → /local → Stripe → dashboard, unchanged.
- [ ] User closes tab during the 1.2s overlay → no stuck cookie on next fresh visit.
- [ ] \`pnpm build\` clean ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)