### PR TITLE
Clear auth state explicitly on signOut

### DIFF
--- a/wrappers/AuthProvider.tsx
+++ b/wrappers/AuthProvider.tsx
@@ -49,6 +49,14 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const signOut = async () => {
     const supabase = createSupabaseBrowserClient();
     await supabase.auth.signOut();
+    // Explicitly clear React state. createSupabaseBrowserClient() returns a
+    // fresh instance each call, so the onAuthStateChange listener installed
+    // above (on a different instance) doesn't fire a SIGNED_OUT event when
+    // we sign out on this one. Without this, `user` stayed set in state
+    // until the next page reload, making the UI look like the user was
+    // still signed in.
+    setUser(null);
+    setSession(null);
   };
 
   return (


### PR DESCRIPTION
Fixes the Sign out button appearing to do nothing.

### Root cause
\`signOut\` in \`wrappers/AuthProvider.tsx\` calls \`createSupabaseBrowserClient()\` which returns a **fresh** client instance. The AuthProvider's mount effect also creates its own instance and installs \`onAuthStateChange\` on it. Each client has its own event bus — a \`signOut\` on one instance clears cookies but doesn't fire the other instance's listener, so the \`user\` React state stays set until the next page reload.

### Fix
After \`signOut()\` resolves, \`setUser(null)\` and \`setSession(null)\` directly. The UI flips immediately.

### Why not share one client via \`useMemo\`?
Tried that first — it broke SSR prerender on \`/chat\`. \`createSupabaseBrowserClient()\` reads env vars at call time, and during static generation the env values aren't available to render. Keeping client creation inside the mount effect (client-only) and explicitly updating state in \`signOut\` is the minimal correct fix.

## Test plan
- [ ] Sign in, click "Sign out" in the header — auth buttons flip to "Log in" immediately (no reload).
- [ ] Refresh the page after — still signed out (cookie was cleared by signOut).
- [ ] \`/local\` redirects to \`/local/onboarding\` after signOut since user=null triggers the existing redirect effect.
- [ ] \`pnpm build\` clean ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)