### PR TITLE
/login post-auth redirect honors pending-action cookie

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,14 +1,36 @@
 'use client';
 
-import { useState, Suspense } from 'react';
+import { useEffect, useState, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
+import { readPendingAction } from '@/lib/pending-action';
 
 function LoginInner() {
   const searchParams = useSearchParams();
-  const redirectTo = searchParams.get('redirectTo') ?? '/';
+  const urlRedirectTo = searchParams.get('redirectTo');
+  // Resolution priority: explicit ?redirectTo= URL param > pending-action
+  // cookie (so a mid-flow user who ended up on /login gets bounced back to
+  // /local or /local/onboarding to run the kickoff) > `/` home.
+  const [resolvedRedirect, setResolvedRedirect] = useState<string>(
+    urlRedirectTo ?? '/',
+  );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (urlRedirectTo) {
+      setResolvedRedirect(urlRedirectTo);
+      return;
+    }
+    const pending = readPendingAction();
+    if (pending?.type === 'subscribe') {
+      setResolvedRedirect('/local');
+    } else if (pending?.type === 'request') {
+      setResolvedRedirect('/local/onboarding');
+    } else {
+      setResolvedRedirect('/');
+    }
+  }, [urlRedirectTo]);
 
   const handleGoogleSignIn = async () => {
     setError('');
@@ -17,7 +39,7 @@ function LoginInner() {
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
       options: {
-        redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(redirectTo)}`,
+        redirectTo: `${window.location.origin}/auth/callback?next=${encodeURIComponent(resolvedRedirect)}`,
       },
     });
     if (error) {


### PR DESCRIPTION
Fixes the "after logging in I should go to /local but I end up at /" case.

### Root cause
The header's "Log in" link (\`components/common/components/auth-buttons.tsx:21\`) is \`<Link href="/login">\` — no \`?redirectTo=\`. \`app/login/page.tsx:9\` defaulted to \`/\`. A user with a pending \`nv_pending_action\` cookie (mid-onboarding, abandoned OAuth, or came in via header Log in) ended up on the home page after auth, the cookie still set but no \`/local\` consumer to trigger the Stripe kickoff.

### Fix
\`/login\` now resolves the post-auth redirect in priority order:

1. \`?redirectTo=\` URL param if explicitly set (keeps \`/chat\`'s auth-redirect behavior working — see \`app/chat/page.tsx:209\`).
2. Else \`readPendingAction()\` cookie:
   - \`type: "subscribe"\` → \`/local\` (kickoff fires the Stripe POST there).
   - \`type: "request"\` → \`/local/onboarding\` (wizard reads the cookie, submits waitlist, step 3).
3. Else \`/\` (unchanged).

Cookie read runs in a \`useEffect\` so it never executes during SSR prerender.

## Test plan
- [ ] Sign out, write a subscribe \`nv_pending_action\` cookie manually (or abandon an OAuth mid-flow), navigate to \`/login\`, click "Continue with Google" → should land at \`/local\` → "Finishing your setup…" → Stripe.
- [ ] Same but cookie is \`type: "request"\` → should land at \`/local/onboarding\` → request-cookie effect in wizard fires → step 3.
- [ ] \`/login?redirectTo=/chat\` with a subscribe cookie → \`/chat\` (URL param takes precedence).
- [ ] Plain \`/login\` with no cookie → \`/\` (unchanged).
- [ ] \`pnpm build\` clean ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)