### PR TITLE
/login post-auth default redirect to /local

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,36 +1,19 @@
 'use client';
 
-import { useEffect, useState, Suspense } from 'react';
+import { useState, Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { createSupabaseBrowserClient } from '@/lib/supabase/client';
-import { readPendingAction } from '@/lib/pending-action';
 
 function LoginInner() {
   const searchParams = useSearchParams();
-  const urlRedirectTo = searchParams.get('redirectTo');
-  // Resolution priority: explicit ?redirectTo= URL param > pending-action
-  // cookie (so a mid-flow user who ended up on /login gets bounced back to
-  // /local or /local/onboarding to run the kickoff) > `/` home.
-  const [resolvedRedirect, setResolvedRedirect] = useState<string>(
-    urlRedirectTo ?? '/',
-  );
+  // Default post-auth destination is /local. /local itself routes based on
+  // subscription state and the nv_pending_action cookie (dashboard for
+  // subscribers; Stripe kickoff for subscribe-intent; otherwise bounce to
+  // /local/onboarding — which also reads the cookie for request-flow users).
+  // Explicit ?redirectTo= (e.g. from /chat's unauth redirect) still wins.
+  const resolvedRedirect = searchParams.get('redirectTo') ?? '/local';
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
-
-  useEffect(() => {
-    if (urlRedirectTo) {
-      setResolvedRedirect(urlRedirectTo);
-      return;
-    }
-    const pending = readPendingAction();
-    if (pending?.type === 'subscribe') {
-      setResolvedRedirect('/local');
-    } else if (pending?.type === 'request') {
-      setResolvedRedirect('/local/onboarding');
-    } else {
-      setResolvedRedirect('/');
-    }
-  }, [urlRedirectTo]);
 
   const handleGoogleSignIn = async () => {
     setError('');


### PR DESCRIPTION
## Summary
- Drops the cookie-reading branch on `/login` (added in #96) in favor of a simple default: `searchParams.get('redirectTo') ?? '/local'`.
- `/local` is already cookie-aware and routes to all four post-auth outcomes (dashboard, subscribe kickoff, bounce to onboarding for subscribe-without-sub, bounce to onboarding for request mode), so `/login` doesn't need to branch on cookie type.
- Covers cases #96 missed: users who hit `/login` without a pending cookie — header "Log in" click before touching the wizard, or mid-wizard before the plan CTA writes the cookie — now land on `/local` too (instead of `/`).
- Explicit `?redirectTo=` still wins, so `/chat`'s unauth redirect (`app/chat/page.tsx:209`) is preserved.

## Test plan
- [ ] Mid-wizard subscribe → close Google tab → click header "Log in" → sign in → lands on `/local` → "Finishing your setup…" → Stripe opens
- [ ] Mid-wizard request (unsupported city) → close Google tab → header "Log in" → sign in → `/local` flashes → bounces to `/local/onboarding` → waitlist auto-submits → step 3 renders
- [ ] Fresh user → `/login` directly → sign in → `/local` → bounces to `/local/onboarding` step 1
- [ ] `/chat` unauth redirect: visit `/chat` logged-out → sent to `/login?redirectTo=%2Fchat` → sign in → lands on `/chat`
- [ ] Existing subscriber → `/login` → sign in → `/local` → dashboard renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)