### PR TITLE
Count referral conversions from region_votes, not referrals.status

### DIFF
--- a/server-actions/referrals.ts
+++ b/server-actions/referrals.ts
@@ -101,6 +101,12 @@ export async function convertReferral(
 
 /**
  * Get referral stats for a user's dashboard.
+ *
+ * Conversions are sourced from region_votes, which records every
+ * waitlist signup with the recipient's referral_code. The referrals
+ * table can only hold one signed_up status per code due to the UNIQUE
+ * constraint on referral_code, so reading conversions from there
+ * undercounts when a single shared link drives multiple signups.
  */
 export async function getReferralStats(email: string): Promise<{
   totalReferrals: number;
@@ -110,20 +116,28 @@ export async function getReferralStats(email: string): Promise<{
 }> {
   const supabase = createSupabaseAdminClient();
 
-  const { data, error } = await supabase
+  const { data: refs, error } = await supabase
     .from("referrals")
-    .select("status")
+    .select("referral_code, status")
     .eq("referrer_email", email);
 
-  if (error || !data) {
+  if (error || !refs) {
     return { totalReferrals: 0, totalClicked: 0, totalConverted: 0, kFactor: 0 };
   }
 
-  const totalReferrals = data.length;
-  const totalClicked = data.filter((r) => r.status !== "pending").length;
-  const totalConverted = data.filter(
-    (r) => r.status === "signed_up" || r.status === "subscribed",
-  ).length;
+  const totalReferrals = refs.length;
+  const totalClicked = refs.filter((r) => r.status !== "pending").length;
+
+  let totalConverted = 0;
+  if (refs.length > 0) {
+    const codes = refs.map((r) => r.referral_code);
+    const { count } = await supabase
+      .from("region_votes")
+      .select("*", { count: "exact", head: true })
+      .in("referral_code", codes);
+    totalConverted = count ?? 0;
+  }
+
   const kFactor = totalReferrals > 0 ? totalConverted / totalReferrals : 0;
 
   return { totalReferrals, totalClicked, totalConverted, kFactor };


### PR DESCRIPTION
## Summary

Fixes a multi-conversion attribution bug in the K-factor dashboard. `referrals.referral_code` is `UNIQUE`, so the existing `getReferralStats` capped at one signed-up row per code — meaning when a user shared their link broadly and many friends signed up, the dashboard only credited the first conversion.

`region_votes` already writes a row for every waitlist signup with the recipient's `referral_code`, so it's the ground truth for "how many people signed up via this user's link". This change reads `totalConverted` from there.

No schema migration. `convertReferral` and `trackReferralClick` are unchanged — `referrals` remains the code-ownership / first-conversion audit row, and `region_votes` is now the authoritative count for the dashboard.

## Test plan

- [ ] User A's referral row exists (`getOrCreateReferralCode` on first dashboard view)
- [ ] User A shares the link; users B and C both submit `/request-region` requests with `?ref=A's-code`
- [ ] Verify `region_votes` has 2 rows with `referral_code = A's-code`
- [ ] Open A's `/local` dashboard → "signed up" reads 2 (was 1 before)
- [ ] K-factor reflects 2 conversions
- [ ] Existing email-invite path still works (rows in `referrals` with `code_timestamp` aren't double-counted because they're never written into `region_votes`)
- [ ] `pnpm build` passes (verified locally)

## Known follow-ups (out of scope)

- For copy-link-only sharers, `totalReferrals` ("sent") still equals the count of rows in `referrals`, which is just 1 + email-invite count. K-factor display can therefore exceed 100% for power-sharers (e.g. "1 sent, 50 signed up, 5000%"). Pure presentation polish.
- Email-invite `code_timestamp` rows in `referrals` are still effectively dead audit log; clicks/conversions never update them. Pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)