### PR TITLE
/auth/callback: always redirect to /local, drop ?next= reliance

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,10 +1,22 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { createSupabaseServerClient } from '@/lib/supabase/server';
 
+// Always redirect post-auth users to /local. /local is cookie-aware and
+// handles every flow:
+//   - subscribe-intent cookie -> fires Stripe kickoff
+//   - request-intent cookie  -> bounces to /local/onboarding (wizard auto-
+//                               submits the waitlist)
+//   - existing subscriber    -> SubscriptionDashboard
+//   - fresh user, no cookie  -> bounces to /local/onboarding (step 1)
+//
+// We deliberately do NOT honor a `?next=` query param. Supabase strict-
+// matches the redirect URL whitelist and strips/rejects query strings on
+// the OAuth callback, so any `?next=` we pass through `signInWithOAuth`
+// would arrive empty here and the user would land on the Site URL (/).
+// Hard-coding /local removes that fragile coupling entirely.
 export async function GET(request: NextRequest) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get('code');
-  const next = searchParams.get('next') ?? '/';
 
   let exchangeFailed = !code;
 
@@ -18,9 +30,9 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  if (exchangeFailed && next.startsWith('/local/onboarding')) {
+  if (exchangeFailed) {
     return NextResponse.redirect(`${origin}/local/onboarding?error=oauth_failed`);
   }
 
-  return NextResponse.redirect(`${origin}${next}`);
+  return NextResponse.redirect(`${origin}/local`);
 }


### PR DESCRIPTION
## Summary
- Wizard sign-up users were landing on \`/\` after Google OAuth instead of \`/local\` — Supabase's redirect URL whitelist strict-matches and strips/rejects the \`?next=/local\` query, so our callback was reached without a \`next\` param and fell through to the previous \`'/'\` default.
- Fix: hard-code \`/auth/callback\` to redirect to \`/local\` on success and \`/local/onboarding?error=oauth_failed\` on failure. Removes fragile coupling to whitelist exact-match behavior.
- \`/local\` already cookie-aware: subscribe-intent → Stripe kickoff; request-intent → bounce to \`/local/onboarding\` for auto-submit; existing sub → dashboard; fresh user → onboarding step 1.

## Test plan
- [ ] Mid-wizard subscribe path: city + plan + click 'Start free/pro' → Google sign-in → lands on \`/local\` → "Finishing your setup…" → Stripe checkout opens
- [ ] Mid-wizard request path (unsupported city): sign-in → \`/local\` flashes → bounces to \`/local/onboarding\` → wizard auto-submits waitlist → step 3 renders
- [ ] Fresh user via header "Log in": no cookie → sign-in → \`/local\` → bounces to \`/local/onboarding\` step 1
- [ ] Existing subscriber: sign-in → \`/local\` → \`SubscriptionDashboard\` renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)