### PR TITLE
proxy: forward OAuth ?code= from Site URL to /auth/callback

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -8,6 +8,21 @@ const isPathAdminMatch = (route: string) => {
 export default async function proxy(req: NextRequest) {
   const route = req.nextUrl.pathname;
 
+  // OAuth fallback: when Supabase rejects the `redirectTo` we pass in
+  // `signInWithOAuth` (because `${origin}/auth/callback?next=/local` doesn't
+  // strict-match the project's whitelisted redirect URLs), Supabase falls
+  // back to the project Site URL and appends `?code=…` there. The user
+  // lands on `/` and our `/auth/callback` route never runs, so the PKCE
+  // exchange never completes. Forward any `?code=` to `/auth/callback`
+  // wherever it arrives so the existing handler can finish auth and route
+  // the user to `/local`.
+  const code = req.nextUrl.searchParams.get("code");
+  if (code && route !== "/auth/callback") {
+    const target = req.nextUrl.clone();
+    target.pathname = "/auth/callback";
+    return NextResponse.redirect(target);
+  }
+
   // Admin routes: redirect to home (admin access disabled)
   if (isPathAdminMatch(route)) {
     const homeURL = new URL("/", req.url);


### PR DESCRIPTION
## Summary
Wizard sign-up users were still landing on \`/\` after Google OAuth, even after PR #101 hard-coded \`/auth/callback\` to redirect to \`/local\`. Verified via curl: \`/auth/callback\` was deployed and working — but \`/auth/callback\` was never being hit because Supabase rejects our \`redirectTo\` (whitelist mismatch on the query string) and falls back to the project Site URL, dropping the OAuth \`?code=\` at \`/\` instead.

This adds a forward in \`proxy.ts\`: any request with \`?code=\` on a path other than \`/auth/callback\` redirects there, so the PKCE exchange always runs.

## Test plan
- [ ] Wizard subscribe flow → Google sign-in → lands on /local → "Finishing your setup…" → Stripe Checkout opens
- [ ] Wizard request flow (unsupported city) → sign-in → /local flashes → bounces to /local/onboarding → waitlist auto-submits
- [ ] Fresh user via header "Log in" → sign-in → /local → bounces to /local/onboarding step 1
- [ ] Existing subscriber → sign-in → /local → dashboard renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)