### PR TITLE
pending-action: rename cookie to *_v2 for clean cutover

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -7,7 +7,7 @@ import { createSupabaseBrowserClient } from '@/lib/supabase/client';
 function LoginInner() {
   const searchParams = useSearchParams();
   // Default post-auth destination is /local. /local itself routes based on
-  // subscription state and the nv_pending_action cookie (dashboard for
+  // subscription state and the nv_pending_action_v2 cookie (dashboard for
   // subscribers; Stripe kickoff for subscribe-intent; otherwise bounce to
   // /local/onboarding — which also reads the cookie for request-flow users).
   // Explicit ?redirectTo= (e.g. from /chat's unauth redirect) still wins.

--- a/lib/pending-action.ts
+++ b/lib/pending-action.ts
@@ -31,7 +31,12 @@ interface StoredPendingAction {
   action: PendingAction;
 }
 
-const COOKIE_NAME = "nv_pending_action";
+// Bumped from `nv_pending_action` to `_v2` for a clean cutover after the
+// post-OAuth flow rewrite (PRs #98 / #101 / #102). Anyone with a stale
+// legacy cookie set by the older code is intentionally ignored — they
+// fall back to a fresh wizard run, which is the desired behavior.
+const COOKIE_NAME = "nv_pending_action_v2";
+const LEGACY_COOKIE_NAME = "nv_pending_action";
 const MAX_AGE_SECONDS = 15 * 60;
 const MAX_AGE_MS = MAX_AGE_SECONDS * 1000;
 
@@ -120,4 +125,8 @@ export function readPendingAction(): PendingAction | null {
 export function clearPendingAction(): void {
   if (typeof document === "undefined") return;
   document.cookie = `${COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax`;
+  // Defensive: also wipe any legacy cookie still sitting in the browser
+  // from a session that started before the rename. The new code never
+  // reads it, but actively clearing keeps the cookie jar clean.
+  document.cookie = `${LEGACY_COOKIE_NAME}=; Path=/; Max-Age=0; SameSite=Lax`;
 }


### PR DESCRIPTION
## Summary
Renames the onboarding cookie \`nv_pending_action\` → \`nv_pending_action_v2\` so users with stale cookies set by the older flow (pre #98 / #101 / #102) don't inherit state into the new flow.

- New code reads/writes \`nv_pending_action_v2\` only.
- \`clearPendingAction()\` defensively wipes the legacy name too, so a clean kickoff or 409 path leaves a tidy cookie jar.
- All call sites already go through \`writePendingAction\` / \`readPendingAction\` / \`clearPendingAction\`, so the rename is one-constant + one-defensive-clear.

## Test plan
- [ ] Wizard subscribe path → cookie set in DevTools is \`nv_pending_action_v2\` → /local kickoff fires → Stripe opens → both \`nv_pending_action\` and \`_v2\` absent after redirect
- [ ] Manually plant a \`nv_pending_action\` cookie via DevTools → reload \`/local\` → no kickoff fires (legacy ignored on read)
- [ ] Wizard request flow → cookie name is \`_v2\` → waitlist auto-submits

🤖 Generated with [Claude Code](https://claude.com/claude-code)