### PR TITLE
local: add past-reports panel alongside subscription settings

### DIFF
--- a/app/api/render/route.ts
+++ b/app/api/render/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from "next/server";
 import { marked } from "marked";
 
 const allowedFileTypes = ["html", "md"];
+const ALLOWED_BUCKETS = new Set(["next-voters-summaries", "reports"]);
 
 export async function GET(req: NextRequest) {
   const filePath = req.nextUrl.searchParams.get("path");
@@ -9,17 +10,30 @@ export async function GET(req: NextRequest) {
     return new Response("Missing ?path=", { status: 400 });
   }
 
-  const [fileName, fileExtension] = filePath.split(".");
+  // Reject anything that could escape the bucket prefix via path traversal.
+  if (
+    filePath.includes("..") ||
+    filePath.startsWith("/") ||
+    filePath.includes("\\")
+  ) {
+    return new Response("Invalid path", { status: 400 });
+  }
 
-  if (!allowedFileTypes.includes(fileExtension)) {
+  const fileExtension = filePath.split(".").pop();
+  if (!fileExtension || !allowedFileTypes.includes(fileExtension)) {
     return new Response("File type not allowed", { status: 403 });
+  }
+
+  const bucket = req.nextUrl.searchParams.get("bucket") ?? "next-voters-summaries";
+  if (!ALLOWED_BUCKETS.has(bucket)) {
+    return new Response("Bucket not allowed", { status: 403 });
   }
 
   const allowedHost = "ihzytkomakaqhkqdrval.supabase.co";
   let url: URL;
 
   try {
-    url = new URL(`https://${allowedHost}/storage/v1/object/public/next-voters-summaries/${filePath}`);
+    url = new URL(`https://${allowedHost}/storage/v1/object/public/${bucket}/${filePath}`);
     if (url.host !== allowedHost) {
       return new Response("Host not allowed", { status: 403 });
     }

--- a/components/local/email-history.tsx
+++ b/components/local/email-history.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowUpRight, Mail } from "lucide-react";
+import {
+  getSubscriberReports,
+  type DateCard,
+} from "@/server-actions/get-subscriber-reports";
+
+const PAGE_SIZE = 10;
+
+const formatDate = (yyyyMmDd: string): string => {
+  const [y, m, d] = yyyyMmDd.split("-").map(Number);
+  if (!y || !m || !d) return yyyyMmDd;
+  return new Date(Date.UTC(y, m - 1, d)).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+};
+
+export function EmailHistory() {
+  const scrollRootRef = useRef<HTMLDivElement>(null);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const inflightRef = useRef(false);
+  const initialLoadedRef = useRef(false);
+  // Drops setState from any in-flight request whose response arrives after the
+  // component has unmounted (the parent remounts us via key={historyVersion}
+  // when settings save, and a stale fetch could otherwise paint old data into
+  // the about-to-unmount instance).
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const [cards, setCards] = useState<DateCard[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [done, setDone] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
+
+  const loadMore = useCallback(async () => {
+    if (inflightRef.current || done) return;
+    inflightRef.current = true;
+    if (!initialLoadedRef.current) setLoading(true);
+    else setLoadingMore(true);
+    try {
+      const res = await getSubscriberReports({ cursor, pageSize: PAGE_SIZE });
+      if (!mountedRef.current) return;
+      setCards((prev) => [...prev, ...res.cards]);
+      setCursor(res.nextCursor);
+      if (!res.nextCursor) setDone(true);
+      initialLoadedRef.current = true;
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false);
+        setLoadingMore(false);
+      }
+      inflightRef.current = false;
+    }
+  }, [cursor, done]);
+
+  useEffect(() => {
+    loadMore();
+    // Initial load only — subsequent loads driven by the observer.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    const root = scrollRootRef.current;
+    if (!sentinel || !root || done) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { root, rootMargin: "0px 0px 200px 0px", threshold: 0 },
+    );
+    observer.observe(sentinel);
+    return () => observer.disconnect();
+  }, [loadMore, done]);
+
+  return (
+    <div className="w-full">
+      <p className="text-[11px] font-bold text-gray-400 uppercase tracking-widest mb-3">
+        Past reports
+      </p>
+      <p className="text-[13px] text-gray-500 mb-4">
+        Reports we&apos;ve sent for your city, topics, and language.
+      </p>
+
+      <div
+        ref={scrollRootRef}
+        className="max-h-[calc(100vh-220px)] overflow-y-auto pr-1 -mr-1"
+      >
+        {loading && cards.length === 0 ? (
+          <p className="text-gray-400 text-[13px] py-4">Loading…</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {cards.map((card) => (
+              <DateCardView key={card.date} card={card} />
+            ))}
+
+            {!done && (
+              <div
+                ref={sentinelRef}
+                className="py-4 text-center text-[12px] text-gray-400"
+                aria-hidden="true"
+              >
+                {loadingMore ? "Loading more…" : " "}
+              </div>
+            )}
+
+            {done && cards.length === 0 && (
+              <div className="border border-dashed border-gray-200 rounded-xl px-4 py-8 text-center">
+                <Mail className="h-5 w-5 text-gray-300 mx-auto mb-2" aria-hidden="true" />
+                <p className="text-[13.5px] text-gray-500">
+                  No reports yet. Your first one is on the way.
+                </p>
+              </div>
+            )}
+
+            {done && cards.length > 0 && (
+              <p className="py-4 text-center text-[12px] text-gray-400">
+                You&apos;re all caught up.
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function DateCardView({ card }: { card: DateCard }) {
+  return (
+    <div className="border border-gray-200 rounded-xl bg-white overflow-hidden">
+      <div className="px-4 py-3 border-b border-gray-100 bg-gray-50">
+        <p className="text-[13.5px] font-bold text-gray-900">
+          {formatDate(card.date)}
+        </p>
+      </div>
+      <ul className="divide-y divide-gray-100">
+        {card.reports.map((r) => (
+          <li key={r.topic} className="px-4 py-2.5 flex items-center justify-between gap-3">
+            <span className="text-[14px] text-gray-700 truncate">{r.topic}</span>
+            <a
+              href={r.renderUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-[12.5px] font-bold text-brand hover:text-brand-hover shrink-0"
+            >
+              View
+              <ArrowUpRight className="h-3.5 w-3.5" aria-hidden="true" />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/local/manage-topics.tsx
+++ b/components/local/manage-topics.tsx
@@ -13,7 +13,7 @@ import { getSupportedLanguages, getUserLanguage } from "@/server-actions/get-sup
 import { updateUserLanguage } from "@/server-actions/update-user-language";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 
-export function ManageTopics() {
+export function ManageTopics({ onSaved }: { onSaved?: () => void } = {}) {
   const { isPro, isLoading: subLoading, tier } = useSubscription();
   const MAX_TOPICS = isPro ? 3 : 1;
 
@@ -71,6 +71,7 @@ export function ManageTopics() {
       setSavedMsg(error);
     } else {
       setSavedMsg("Saved!");
+      onSaved?.();
     }
   };
 
@@ -84,7 +85,7 @@ export function ManageTopics() {
 
   return (
     <div className="w-full bg-page flex flex-col">
-      <div className="flex-1 w-full max-w-[560px] mx-auto px-5 sm:px-6 pt-12 pb-8">
+      <div className="flex-1 w-full pt-12 pb-8">
         <div className="flex items-center gap-2.5 mb-3">
           <h1 className="text-[30px] sm:text-[38px] font-bold text-gray-950 leading-tight tracking-tight">
             NV Local

--- a/components/local/subscription-dashboard.tsx
+++ b/components/local/subscription-dashboard.tsx
@@ -5,6 +5,7 @@ import { Mail, CheckCircle2, Link2, Users } from 'lucide-react';
 import { useAuth } from '@/hooks/use-auth';
 import { useSubscription } from '@/hooks/use-subscription';
 import { ManageTopics } from '@/components/local/manage-topics';
+import { EmailHistory } from '@/components/local/email-history';
 import { createReferral, getOrCreateReferralCode, getReferralStats } from '@/server-actions/referrals';
 import { buildReferralLink } from '@/lib/referral';
 import {
@@ -30,6 +31,8 @@ export function SubscriptionDashboard() {
   const [referralCode, setReferralCode] = useState<string | null>(null);
   const [referralLink, setReferralLink] = useState<string | null>(null);
   const [linkCopied, setLinkCopied] = useState(false);
+  // Bumped on settings save → remounts EmailHistory so it refetches from page 1.
+  const [historyVersion, setHistoryVersion] = useState(0);
   const [stats, setStats] = useState<{
     totalReferrals: number;
     totalClicked: number;
@@ -124,13 +127,16 @@ export function SubscriptionDashboard() {
   };
 
   return (
-    <div className="w-full min-h-[calc(100vh-56px)] bg-page flex flex-col">
-      {/* ManageTopics handles topic selection, tier display, and upgrade prompt */}
-      <ManageTopics />
+    <div className="w-full min-h-[calc(100vh-56px)] bg-page">
+      <div className="w-full max-w-[1200px] mx-auto px-5 sm:px-6 grid gap-8 md:gap-12 md:grid-cols-2">
+        {/* LEFT: settings */}
+        <div className="flex flex-col">
+          {/* ManageTopics handles topic selection, tier display, and upgrade prompt */}
+          <ManageTopics onSaved={() => setHistoryVersion((v) => v + 1)} />
 
-      {/* Subscription actions */}
-      <div className="w-full max-w-[560px] mx-auto px-5 sm:px-6 pb-8">
-        <div className="border-t border-gray-200 pt-8 mt-8">
+          {/* Subscription actions */}
+          <div className="w-full pb-8">
+            <div className="border-t border-gray-200 pt-8 mt-8">
           <p className="text-[11px] font-bold text-gray-400 uppercase tracking-widest mb-5">
             Subscription
           </p>
@@ -251,6 +257,14 @@ export function SubscriptionDashboard() {
               </div>
             </div>
           )}
+            </div>
+          </div>
+        </div>
+
+        {/* RIGHT: past reports — sticky on desktop so it stays in view as the
+            left settings pane scrolls. */}
+        <div className="md:sticky md:top-12 md:self-start pt-12 pb-8">
+          <EmailHistory key={historyVersion} />
         </div>
       </div>
 

--- a/lib/report-paths.ts
+++ b/lib/report-paths.ts
@@ -1,0 +1,13 @@
+export const LANGUAGE_CODE: Record<string, string> = {
+  English: "en",
+  Spanish: "es",
+  French: "fr",
+};
+
+export const slugify = (s: string): string =>
+  s.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
+
+export const citySlug = (city: string): string => slugify(city);
+export const topicSlug = (topic: string): string => slugify(topic);
+export const languageCode = (lang: string): string | null =>
+  LANGUAGE_CODE[lang] ?? null;

--- a/server-actions/get-subscriber-reports.ts
+++ b/server-actions/get-subscriber-reports.ts
@@ -1,0 +1,208 @@
+"use server";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { citySlug, topicSlug, languageCode } from "@/lib/report-paths";
+import { getUserTopics } from "@/server-actions/get-user-topics";
+
+export type ReportLink = {
+  topic: string;
+  renderUrl: string;
+};
+
+export type DateCard = {
+  date: string;
+  reports: ReportLink[];
+};
+
+export type GetSubscriberReportsInput = {
+  cursor?: string | null;
+  pageSize?: number;
+};
+
+export type GetSubscriberReportsResult = {
+  cards: DateCard[];
+  nextCursor: string | null;
+};
+
+type CursorPayload = Record<string, number>;
+
+const REPORT_FILE_RE = /^(\d{4}-\d{2}-\d{2})\.html$/;
+const DEFAULT_PAGE_SIZE = 10;
+const FETCH_MULTIPLIER = 3;
+
+const decodeCursor = (cursor: string | null | undefined): CursorPayload => {
+  if (!cursor) return {};
+  try {
+    const json = Buffer.from(cursor, "base64").toString("utf8");
+    const parsed = JSON.parse(json);
+    if (parsed && typeof parsed === "object") {
+      return parsed as CursorPayload;
+    }
+    return {};
+  } catch {
+    return {};
+  }
+};
+
+const encodeCursor = (payload: CursorPayload): string =>
+  Buffer.from(JSON.stringify(payload), "utf8").toString("base64");
+
+export async function getSubscriberReports(
+  input?: GetSubscriberReportsInput,
+): Promise<GetSubscriberReportsResult> {
+  const pageSize = Math.max(1, input?.pageSize ?? DEFAULT_PAGE_SIZE);
+  const fetchPerTopic = pageSize * FETCH_MULTIPLIER;
+
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user?.email) return { cards: [], nextCursor: null };
+
+  const email = user.email.toLowerCase();
+
+  const { data: sub } = await supabase
+    .from("subscriptions")
+    .select("city, preferred_language")
+    .eq("contact", email)
+    .maybeSingle();
+  if (!sub?.city || !sub?.preferred_language) {
+    return { cards: [], nextCursor: null };
+  }
+
+  const langCode = languageCode(sub.preferred_language);
+  if (langCode === null) {
+    // Unknown language → no storage path will resolve. Bail rather than
+    // silently 404'ing every report URL with an `en/` fallback.
+    return { cards: [], nextCursor: null };
+  }
+
+  const topics = await getUserTopics();
+  if (topics.length === 0) return { cards: [], nextCursor: null };
+
+  const offsets = decodeCursor(input?.cursor);
+  const cSlug = citySlug(sub.city);
+
+  type PerTopic = {
+    topic: string;
+    slug: string;
+    files: { date: string; topic: string }[];
+    exhausted: boolean;
+  };
+
+  const perTopic: PerTopic[] = await Promise.all(
+    topics.map(async (topic): Promise<PerTopic> => {
+      const slug = topicSlug(topic);
+      const offset = offsets[slug] ?? 0;
+      try {
+        const { data, error } = await supabase.storage
+          .from("reports")
+          .list(`${cSlug}/${slug}/${langCode}`, {
+            limit: fetchPerTopic,
+            offset,
+            sortBy: { column: "name", order: "desc" },
+          });
+        if (error || !data) {
+          return { topic, slug, files: [], exhausted: true };
+        }
+        const files = data
+          .map((row) => {
+            const m = row.name.match(REPORT_FILE_RE);
+            return m ? { date: m[1], topic } : null;
+          })
+          .filter((x): x is { date: string; topic: string } => x !== null);
+        return {
+          topic,
+          slug,
+          files,
+          exhausted: data.length < fetchPerTopic,
+        };
+      } catch {
+        return { topic, slug, files: [], exhausted: true };
+      }
+    }),
+  );
+
+  // For each non-exhausted topic, its batch's last entry is the oldest date
+  // we have visibility for in that topic. Dates strictly NEWER than that are
+  // fully known for that topic. The conservative cross-topic horizon is the
+  // MAX of those last entries — only above the max can we be sure every
+  // non-exhausted topic has been fully queried (its next batch starts strictly
+  // below its own last entry, so dates above max(last entries) cannot appear
+  // in any future batch from any topic).
+  const horizons = perTopic
+    .filter((r) => !r.exhausted && r.files.length > 0)
+    .map((r) => r.files[r.files.length - 1].date);
+  const horizon =
+    horizons.length === 0
+      ? null
+      : horizons.reduce((a, b) => (a > b ? a : b));
+
+  // When horizon is null (all topics exhausted), include every fetched file.
+  // Otherwise only include dates strictly newer than horizon — those are the
+  // dates for which we have full visibility across every topic.
+  const byDate = new Map<string, Set<string>>();
+  for (const r of perTopic) {
+    for (const f of r.files) {
+      if (horizon !== null && f.date <= horizon) continue;
+      let set = byDate.get(f.date);
+      if (!set) {
+        set = new Set<string>();
+        byDate.set(f.date, set);
+      }
+      set.add(f.topic);
+    }
+  }
+
+  const allDatesDesc = Array.from(byDate.keys()).sort((a, b) =>
+    b.localeCompare(a),
+  );
+  const pageDates = allDatesDesc.slice(0, pageSize);
+  const pageDateSet = new Set(pageDates);
+
+  const cards: DateCard[] = pageDates.map((date) => {
+    const topicSet = byDate.get(date) ?? new Set<string>();
+    const sortedTopics = Array.from(topicSet).sort((a, b) => a.localeCompare(b));
+    return {
+      date,
+      reports: sortedTopics.map((topic) => {
+        const path = `${cSlug}/${topicSlug(topic)}/${langCode}/${date}.html`;
+        return {
+          topic,
+          renderUrl: `/api/render?bucket=reports&path=${encodeURIComponent(path)}`,
+        };
+      }),
+    };
+  });
+
+  // New offsets: old + count of files from each topic that landed in this page.
+  const newOffsets: CursorPayload = { ...offsets };
+  for (const r of perTopic) {
+    const consumed = r.files.filter((f) => pageDateSet.has(f.date)).length;
+    newOffsets[r.slug] = (offsets[r.slug] ?? 0) + consumed;
+  }
+
+  const allExhausted = perTopic.every((r) => r.exhausted);
+
+  // Defensive: if no dates survived the horizon filter but topics aren't
+  // exhausted, we'd return { cards: [], nextCursor: <unchanged offsets> } and
+  // loop forever. This can happen with pathological data (multiple files
+  // sharing the same date that exactly hits the horizon). Force forward
+  // progress by advancing every non-exhausted topic past the current batch.
+  if (cards.length === 0 && !allExhausted) {
+    for (const r of perTopic) {
+      if (!r.exhausted) {
+        newOffsets[r.slug] = (offsets[r.slug] ?? 0) + r.files.length;
+      }
+    }
+    return { cards: [], nextCursor: encodeCursor(newOffsets) };
+  }
+
+  const moreInBatch = allDatesDesc.length > pageDates.length;
+  const hasMore = !allExhausted || moreInBatch;
+
+  return {
+    cards,
+    nextCursor: hasMore ? encodeCursor(newOffsets) : null,
+  };
+}


### PR DESCRIPTION
## Summary
- Splits the `/local` dashboard into a two-column layout — existing settings on the left, new **Past reports** panel on the right.
- Right pane lists every HTML report in the `reports` Supabase bucket that matches the user's `city × topics × language`, paginated with **server-side cursor pagination** (10 cards/page, infinite scroll within the pane's own scroll root).
- Pagination algorithm uses a "horizon date" — `MAX` of the last entries of every non-exhausted topic batch — to guarantee no card is returned with an incomplete topic list and no date appears in two consecutive pages. Includes a defensive forward-progress guard so the cursor never stalls on pathological data.
- `/api/render` now accepts an allowlisted `?bucket=` so the same proxy serves both the legacy `next-voters-summaries` bucket and the new `reports` bucket. The existing confirmation-email flow keeps working unchanged (no `bucket` param = legacy default).

## Files
- **New:** `lib/report-paths.ts`, `server-actions/get-subscriber-reports.ts`, `components/local/email-history.tsx`
- **Modified:** `app/api/render/route.ts`, `components/local/manage-topics.tsx` (added `onSaved` callback, dropped inner `max-w` so it fits a column), `components/local/subscription-dashboard.tsx` (split into `md:grid-cols-2`; remounts `EmailHistory` via `key={historyVersion}` on save to reset pagination)

## Hardening applied during review
- Render route rejects `..`, leading `/`, and `\` in `path` (path traversal)
- Render route uses `.split(".").pop()` (was destructure that broke for paths with multiple dots)
- Slugify strips all non-`[a-z0-9]` chars (robust for future cities with punctuation)
- `formatDate` uses UTC so storage dates don't shift west of the date line
- `EmailHistory` has a `mountedRef` guard so an in-flight fetch can't paint stale data into an about-to-unmount instance after settings save
- `languageCode` returns `null` for unknown languages and the action short-circuits, instead of silently 404'ing every URL with an `en/` fallback
- `subscriptions.contact` lookup lowercases `user.email` defensively

## Test plan
- [ ] `/local` shows two columns on desktop, stacked on mobile
- [ ] Right pane lists known dates for the signed-in user's city × topics × `en` (e.g. Toronto: `2026-04-18`, `2026-04-20`)
- [ ] "View" opens the rendered HTML in a new tab via `/api/render?bucket=reports&path=...`
- [ ] Scroll the right pane fires a fresh server action call per batch (visible in Network tab carrying the previous `nextCursor`); no duplicate cards across batches
- [ ] Change topics in the left pane → save → right pane re-fetches from page 1
- [ ] Existing confirmation-email links (legacy bucket) still resolve through `/api/render` with no `bucket` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)