### PR TITLE
local: list reports via admin client to bypass storage.objects RLS

### DIFF
--- a/server-actions/get-subscriber-reports.ts
+++ b/server-actions/get-subscriber-reports.ts
@@ -1,6 +1,7 @@
 "use server";
 
 import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { createSupabaseAdminClient } from "@/lib/supabase/admin";
 import { citySlug, topicSlug, languageCode } from "@/lib/report-paths";
 import { getUserTopics } from "@/server-actions/get-user-topics";
 
@@ -83,6 +84,11 @@ export async function getSubscriberReports(
   const offsets = decodeCursor(input?.cursor);
   const cSlug = citySlug(sub.city);
 
+  // The cookie-based server client has no SELECT RLS on storage.objects, so
+  // .list() would silently return []. Auth check above already validated the
+  // user; switch to the admin client for the privileged listing only.
+  const storage = createSupabaseAdminClient();
+
   type PerTopic = {
     topic: string;
     slug: string;
@@ -95,7 +101,7 @@ export async function getSubscriberReports(
       const slug = topicSlug(topic);
       const offset = offsets[slug] ?? 0;
       try {
-        const { data, error } = await supabase.storage
+        const { data, error } = await storage.storage
           .from("reports")
           .list(`${cSlug}/${slug}/${langCode}`, {
             limit: fetchPerTopic,


### PR DESCRIPTION
## Summary
- The Past-reports panel was always empty, even when matching files exist in the `reports` bucket.
- Root cause: `storage.objects` has RLS enabled but no SELECT policy. The cookie-based server client (anon role + user JWT) cannot list, so `.storage.from("reports").list(...)` silently returned `[]`. The bucket being marked `public: true` only enables anonymous downloads via the public URL — it does NOT grant the LIST permission via the Storage API.
- Fix: keep auth + subscription lookup on the user-context client (unchanged), but use the existing `createSupabaseAdminClient()` (service-role key) for the storage `.list()` call only. Service role bypasses RLS.

## Why this is safe
- The auth check still happens against the user's session (we look up *their* subscription row).
- The admin client is only used to enumerate file keys at the path derived from the authenticated user's own city × topics × language.
- No widening of public read surface — public download URLs are unchanged, and we don't add a permissive SELECT policy that would let anyone enumerate every key in every public bucket.

## Test plan
- [ ] Sign in as a subscriber whose city × topics × language matches files in the `reports` bucket → right pane lists the matching dates with one "View" link per subscribed topic
- [ ] Click "View" → opens the rendered HTML via `/api/render?bucket=reports&path=...`
- [ ] Existing confirmation-email flow (separate code path on `next-voters-summaries`) unaffected
- [ ] `npx tsc --noEmit` clean

## Follow-up
`lib/supabase-helper.ts:getLastSummaryFolder()` (used by `sendConfirmationEmail`) hits the same RLS wall against the `next-voters-summaries` bucket. Worth migrating it to the admin client in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)