### PR TITLE
local: include horizon date itself in past-reports listing

### DIFF
--- a/server-actions/get-subscriber-reports.ts
+++ b/server-actions/get-subscriber-reports.ts
@@ -130,12 +130,12 @@ export async function getSubscriberReports(
   );
 
   // For each non-exhausted topic, its batch's last entry is the oldest date
-  // we have visibility for in that topic. Dates strictly NEWER than that are
-  // fully known for that topic. The conservative cross-topic horizon is the
-  // MAX of those last entries — only above the max can we be sure every
-  // non-exhausted topic has been fully queried (its next batch starts strictly
-  // below its own last entry, so dates above max(last entries) cannot appear
-  // in any future batch from any topic).
+  // we have visibility for in that topic — every report it has on that date
+  // or newer is already in `files`. The cross-topic horizon is the MAX of
+  // those last entries: at the max, every non-exhausted topic's batch still
+  // covers that date (its own last entry is <= max), so we have full
+  // cross-topic visibility for dates >= horizon. Below the horizon, the
+  // topic that set the max may have unread reports waiting in its next page.
   const horizons = perTopic
     .filter((r) => !r.exhausted && r.files.length > 0)
     .map((r) => r.files[r.files.length - 1].date);
@@ -145,12 +145,12 @@ export async function getSubscriberReports(
       : horizons.reduce((a, b) => (a > b ? a : b));
 
   // When horizon is null (all topics exhausted), include every fetched file.
-  // Otherwise only include dates strictly newer than horizon — those are the
-  // dates for which we have full visibility across every topic.
+  // Otherwise include dates >= horizon — those are the dates for which every
+  // non-exhausted topic's batch already covers any report it might have.
   const byDate = new Map<string, Set<string>>();
   for (const r of perTopic) {
     for (const f of r.files) {
-      if (horizon !== null && f.date <= horizon) continue;
+      if (horizon !== null && f.date < horizon) continue;
       let set = byDate.get(f.date);
       if (!set) {
         set = new Set<string>();


### PR DESCRIPTION
## Summary

- Fix off-by-one in `getSubscriberReports` horizon filter that was hiding yesterday's San Francisco report (and any other date that happened to coincide with the cross-topic horizon).
- The horizon = MAX of each non-exhausted topic batch's oldest entry — by construction the horizon date itself sits within every non-exhausted topic's visible window, so we have full cross-topic visibility *at* the horizon, not just strictly above it. Predicate `f.date <= horizon` → `f.date < horizon`.
- Refreshed the surrounding comment block so it reflects the corrected reasoning.

## Test plan

- [ ] Sign in as a subscriber whose `subscriptions.city = "San Francisco"`, language English, with a topic that has a Supabase Storage object at `reports/san-francisco/{topic-slug}/en/{yesterday}.html`. Confirm yesterday's date appears as the top "Past reports" card on `/local`.
- [ ] Scroll to trigger the IntersectionObserver — older pages still load without duplicating yesterday's card.
- [ ] Sanity check on a subscriber who has no SF report for yesterday — the panel renders normally with whatever earlier dates exist.

https://claude.ai/code/session_013J9i2BdijvxZ5JuUZzbL9T

---
_Generated by [Claude Code](https://claude.ai/code/session_013J9i2BdijvxZ5JuUZzbL9T)_