### PR TITLE
local: query subscriptions with raw user.email, not lowercased

### DIFF
--- a/server-actions/get-subscriber-reports.ts
+++ b/server-actions/get-subscriber-reports.ts
@@ -60,12 +60,14 @@ export async function getSubscriberReports(
   } = await supabase.auth.getUser();
   if (!user?.email) return { cards: [], nextCursor: null };
 
-  const email = user.email.toLowerCase();
-
+  // Match the rest of the codebase, which stores and queries `subscriptions.contact`
+  // and `subscription_topics.subscription_id` using raw `user.email` (no
+  // normalization). Lowercasing here would miss the row when the JWT email has
+  // any uppercase characters.
   const { data: sub } = await supabase
     .from("subscriptions")
     .select("city, preferred_language")
-    .eq("contact", email)
+    .eq("contact", user.email)
     .maybeSingle();
   if (!sub?.city || !sub?.preferred_language) {
     return { cards: [], nextCursor: null };


### PR DESCRIPTION
## Summary

- Fix `getSubscriberReports` query that lowercased `user.email` before looking up the row in `subscriptions.contact`. Every other server-action in the codebase keys `subscriptions.contact` and `subscription_topics.subscription_id` by **raw** `user.email` (writes and reads), so the lowercased lookup misses the row whenever the JWT email contains any uppercase characters (common via Google OAuth).
- When the lookup misses, the function bails at the `!sub?.city` guard and returns an empty cards array — the symptom the user saw as "yesterday's San Francisco report isn't showing" (in fact no reports were showing).
- Drop the `.toLowerCase()` so the read matches the writes; add a comment explaining the invariant.

## Test plan

- [ ] Sign in as a user whose JWT email has uppercase characters (e.g. `User@Example.com` via Google OAuth) and whose `subscriptions` row already exists — confirm the "Past reports" panel on `/local` populates with their dated cards rather than the empty state.
- [ ] Sign in as a user whose email is fully lowercase — confirm no regression; cards still load normally.
- [ ] Sign in as a brand-new user with no `subscriptions` row — confirm the empty state still renders cleanly (function still returns `{ cards: [], nextCursor: null }`).

https://claude.ai/code/session_013J9i2BdijvxZ5JuUZzbL9T

---
_Generated by [Claude Code](https://claude.ai/code/session_013J9i2BdijvxZ5JuUZzbL9T)_