### PR TITLE
local: harden languageCode() against case/whitespace/short-code variants

### DIFF
--- a/lib/report-paths.ts
+++ b/lib/report-paths.ts
@@ -1,13 +1,23 @@
-export const LANGUAGE_CODE: Record<string, string> = {
-  English: "en",
-  Spanish: "es",
-  French: "fr",
+const LANGUAGE_CODE_BY_NAME: Record<string, string> = {
+  english: "en",
+  spanish: "es",
+  french: "fr",
 };
+const KNOWN_LANGUAGE_CODES = new Set(["en", "es", "fr"]);
 
 export const slugify = (s: string): string =>
   s.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
 
 export const citySlug = (city: string): string => slugify(city);
 export const topicSlug = (topic: string): string => slugify(topic);
-export const languageCode = (lang: string): string | null =>
-  LANGUAGE_CODE[lang] ?? null;
+
+// Tolerant of casing, leading/trailing whitespace, and full-name vs
+// short-code form: "English", "english", " EN ", "en" all return "en".
+// Anything we can't recognise returns null so callers fall through to
+// their bail path instead of constructing a bogus storage path.
+export const languageCode = (lang: string): string | null => {
+  const k = lang.trim().toLowerCase();
+  if (!k) return null;
+  if (KNOWN_LANGUAGE_CODES.has(k)) return k;
+  return LANGUAGE_CODE_BY_NAME[k] ?? null;
+};


### PR DESCRIPTION
## Summary

- Past-reports panel was silently rendering empty whenever `subscriptions.preferred_language` didn't match one of `"English"`, `"Spanish"`, `"French"` exactly. The case-sensitive map lookup in `languageCode()` returned `null`, `getSubscriberReports` bailed at the language guard, and the panel showed the empty state — matching the persistent "yesterday's SF report not showing" symptom that survived PR #110 and PR #111.
- Make `languageCode()` tolerant of casing, leading/trailing whitespace, and full-name vs short-code form. `"English"`, `"english"`, `"  ENGLISH  "`, `"en"`, `"EN"`, `" en "` all resolve to `"en"` (and same for `es`/`fr`).
- Unknown values still return `null` so genuinely unsupported languages preserve the existing bail behavior.
- `LANGUAGE_CODE` was the only export removed; verified no other callers via grep before refactoring.

## Test plan

- [ ] Sign in as the affected SF subscriber and confirm the "Past reports" panel on `/local` lists yesterday's report card.
- [ ] Sanity check: a subscriber whose `preferred_language = "English"` (canonical) still sees their reports — no regression.
- [ ] Sanity check: a subscriber whose `preferred_language` is genuinely unsupported (e.g. `"German"`) still sees the empty state, not a broken `/api/render` URL.
- [ ] If the panel is **still** empty after this ships, follow-up plan: add server-side `console.error` at each bail point in `getSubscriberReports` so we can pinpoint which guard is firing in Vercel logs.

https://claude.ai/code/session_013J9i2BdijvxZ5JuUZzbL9T

---
_Generated by [Claude Code](https://claude.ai/code/session_013J9i2BdijvxZ5JuUZzbL9T)_