### PR TITLE
local: list reports under public/sf/... instead of san-francisco/...

### DIFF
--- a/lib/report-paths.ts
+++ b/lib/report-paths.ts
@@ -8,7 +8,17 @@ const KNOWN_LANGUAGE_CODES = new Set(["en", "es", "fr"]);
 export const slugify = (s: string): string =>
   s.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
 
-export const citySlug = (city: string): string => slugify(city);
+// Cities the report writer keys by a short alias rather than the canonical
+// slugified name. Lookup is by lowercased+trimmed input.
+const CITY_SLUG_OVERRIDES: Record<string, string> = {
+  "san francisco": "sf",
+};
+
+export const citySlug = (city: string): string => {
+  const k = city.trim().toLowerCase();
+  return CITY_SLUG_OVERRIDES[k] ?? slugify(city);
+};
+
 export const topicSlug = (topic: string): string => slugify(topic);
 
 // Tolerant of casing, leading/trailing whitespace, and full-name vs

--- a/server-actions/get-subscriber-reports.ts
+++ b/server-actions/get-subscriber-reports.ts
@@ -105,7 +105,7 @@ export async function getSubscriberReports(
       try {
         const { data, error } = await storage.storage
           .from("reports")
-          .list(`${cSlug}/${slug}/${langCode}`, {
+          .list(`public/${cSlug}/${slug}/${langCode}`, {
             limit: fetchPerTopic,
             offset,
             sortBy: { column: "name", order: "desc" },
@@ -174,7 +174,7 @@ export async function getSubscriberReports(
     return {
       date,
       reports: sortedTopics.map((topic) => {
-        const path = `${cSlug}/${topicSlug(topic)}/${langCode}/${date}.html`;
+        const path = `public/${cSlug}/${topicSlug(topic)}/${langCode}/${date}.html`;
         return {
           topic,
           renderUrl: `/api/render?bucket=reports&path=${encodeURIComponent(path)}`,


### PR DESCRIPTION
## Summary

- The reports bucket layout the writer actually uses is `public/{citySlug}/{topicSlug}/{langCode}/{date}.html` (mirroring the legacy `next-voters-summaries` bucket — see `lib/supabase-helper.ts:33`). The reader was building the storage list prefix and `/api/render` path without the `public/` segment, so every `.list()` call returned empty.
- San Francisco is keyed under the `sf` alias (matching the `/local/sf` ad-landing route's `cityAliases`) rather than the default slugified `san-francisco`. Add a small `CITY_SLUG_OVERRIDES` map and route SF through it. Other cities still fall through to `slugify()`.
- Both the `.list()` prefix and the `renderUrl` path are updated, so the Past-reports panel both discovers the files and the `/api/render` proxy resolves them when clicked.

## Test plan

- [ ] Sign in as the affected SF subscriber. Confirm the "Past reports" panel on `/local` lists yesterday's report card and clicking it renders successfully (no upstream 502).
- [ ] Sanity check a non-SF subscriber (e.g. New York City). They should still resolve through `slugify()` to `new-york-city` (or whatever their canonical slug is) — no regression.
- [ ] Verify the storage path in Supabase matches the new format `reports/public/sf/{topic-slug}/en/2026-04-28.html` for yesterday's SF report.

https://claude.ai/code/session_013J9i2BdijvxZ5JuUZzbL9T

---
_Generated by [Claude Code](https://claude.ai/code/session_013J9i2BdijvxZ5JuUZzbL9T)_