### PR TITLE
local: revert sf alias, use slugified city name in reports path

### DIFF
--- a/lib/report-paths.ts
+++ b/lib/report-paths.ts
@@ -8,17 +8,7 @@ const KNOWN_LANGUAGE_CODES = new Set(["en", "es", "fr"]);
 export const slugify = (s: string): string =>
   s.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "");
 
-// Cities the report writer keys by a short alias rather than the canonical
-// slugified name. Lookup is by lowercased+trimmed input.
-const CITY_SLUG_OVERRIDES: Record<string, string> = {
-  "san francisco": "sf",
-};
-
-export const citySlug = (city: string): string => {
-  const k = city.trim().toLowerCase();
-  return CITY_SLUG_OVERRIDES[k] ?? slugify(city);
-};
-
+export const citySlug = (city: string): string => slugify(city);
 export const topicSlug = (topic: string): string => slugify(topic);
 
 // Tolerant of casing, leading/trailing whitespace, and full-name vs


### PR DESCRIPTION
## Summary

- Drops the `CITY_SLUG_OVERRIDES` map introduced in #113 so the SF reports path goes back to the canonical slugified form: `public/san-francisco/{topic-slug}/en/{date}.html`.
- Keeps the `public/` prefix from #113 — that part is correct (mirrors `lib/supabase-helper.ts:33` and `mailer.ts:186`).
- All cities now flow through `slugify(city)` uniformly.

## Test plan

- [ ] Sign in as the affected SF subscriber. Confirm the "Past reports" panel on `/local` lists yesterday's report and clicking renders without a 502.
- [ ] If still empty, the next escalation is to instrument each silent-bail point in `getSubscriberReports` with `console.error` so we can pinpoint which guard fires in Vercel logs.

https://claude.ai/code/session_013J9i2BdijvxZ5JuUZzbL9T

---
_Generated by [Claude Code](https://claude.ai/code/session_013J9i2BdijvxZ5JuUZzbL9T)_